### PR TITLE
[ci] Set empty tsflags while populating envroot

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,6 +7,6 @@ RUN echo 3
 COPY "prepare_ci.sh" "/usr/local/bin/"
 RUN mkdir "/usr/local/src/rpms" && cd "/usr/local/src/rpms" && "/usr/local/bin/prepare_ci.sh"
 
-RUN dnf -y --nogpgcheck --installroot /srv/envroot --setopt reposdir=/dev/null --repofrompath rawhide,https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64 install $(find /usr/local/src/rpms \( -name \*.noarch.rpm -o -name \*.x86_64.rpm \) -a \! -name maven-openjdk\* -a \! -name maven-local-openjdk\*)
+RUN dnf -y --nogpgcheck --installroot /srv/envroot --setopt reposdir=/dev/null --setopt tsflags= --repofrompath rawhide,https://kojipkgs.fedoraproject.org/repos/rawhide/latest/x86_64 install $(find /usr/local/src/rpms \( -name \*.noarch.rpm -o -name \*.x86_64.rpm \) -a \! -name maven-openjdk\* -a \! -name maven-local-openjdk\*)
 
 ENTRYPOINT ["cp", "-r", "/usr/local/src/rpms", "/srv/envroot", "-t"]


### PR DESCRIPTION
Fedora cloud images have tsflags=nodocs setting in dnf.conf, which
cause envroot packages not to install docs.