### PR TITLE
[ci] Limit archful RPMs to x86_64

### DIFF
--- a/prepare_ci.sh
+++ b/prepare_ci.sh
@@ -15,7 +15,7 @@ for component in $(curl -S 'https://mbi-artifacts.s3.eu-central-1.amazonaws.com/
     
     mkdir rpms
     pushd rpms
-    koji download-build --debuginfo "${nevra}"
+    koji download-build --arch noarch --arch x86_64 --arch src --debuginfo "${nevra}"
     popd
 ) & done
 wait


### PR DESCRIPTION
Fedora CI tests only x86_64 RPMs.