### PR TITLE
Throw an exception when no rpms are found

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Check.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Check.java
@@ -173,6 +173,9 @@ public abstract class Check<Config> {
         }
 
         Main.readTestRpmArgs(argList);
+        if (Main.getTestRpms().isEmpty()) {
+            throw new RuntimeException("No test rpms found");
+        }
 
         var messages = new ArrayList<String>();
         for (Config configInstance : configInstances) {


### PR DESCRIPTION
`Main.getTestRpms()` is never null.