### PR TITLE
Minimize executable container image

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -23,8 +23,8 @@ RUN mvn -B clean install
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi9-minimal
-RUN microdnf -y install java-17-openjdk-headless rpm-libs
+FROM docker.io/library/alpine:3.16.2
+RUN apk add rpm openjdk17-jre-headless
 
 COPY --from=builder "/usr/local/src/javapackages-validator/target/dependency/" "/opt/javapackages-validator/dependency/"
 COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -26,9 +26,7 @@ RUN mvn -B clean install
 FROM registry.access.redhat.com/ubi9-minimal
 RUN microdnf -y install java-17-openjdk-headless rpm-libs
 
-COPY --from=builder "/usr/local/src/javapackages-validator/target/" "/opt/javapackages-validator/target/"
-COPY "run.sh" "/opt/javapackages-validator/"
+COPY --from=builder "/usr/local/src/javapackages-validator/target/dependency/" "/opt/javapackages-validator/dependency/"
+COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"
 
-WORKDIR "/opt/javapackages-validator"
-
-ENTRYPOINT ["./run.sh"]
+ENTRYPOINT ["java", "--enable-preview", "--add-modules", "jdk.incubator.foreign", "--enable-native-access", "ALL-UNNAMED", "-jar", "/opt/javapackages-validator/validator.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   </properties>
   
   <build>
+    <finalName>${project.name}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@ set -e
 
 java_bin='/usr/lib/jvm/jre-17/bin'
 
-exec "${java_bin}"/java --enable-preview --add-modules jdk.incubator.foreign --enable-native-access ALL-UNNAMED -jar "$(ls target/*.jar | tail -n1)" ${@}
+exec "${java_bin}"/java --enable-preview --add-modules jdk.incubator.foreign --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' ${@}


### PR DESCRIPTION
This change makes the container from 400 to 218 MB. Alpine is supported for 2 years.