### PR TITLE
Refactorings + removing `getTestRpms`

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/ArgFileIterator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/ArgFileIterator.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 
 public class ArgFileIterator implements Iterator<RpmPathInfo> {
@@ -18,7 +19,7 @@ public class ArgFileIterator implements Iterator<RpmPathInfo> {
         pathIterator = advance();
 
         if (pathIterator == null) {
-            pathIterator = Arrays.<Path>asList().iterator();
+            pathIterator = Collections.<Path>emptyList().iterator();
         }
     }
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/Check.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Check.java
@@ -44,6 +44,15 @@ public abstract class Check<Config> {
     private Class<Config> configClass;
     private Logger logger = new Logger();
 
+    protected static final Decoration DECORATION_RPM = Decoration.bright_red;
+    protected static final Decoration DECORATION_EXPECTED = Decoration.bright_cyan;
+    protected static final Decoration DECORATION_ACTUAL = Decoration.bright_magenta;
+
+    /**
+     * Decoration used for describing objects which hold inspected values
+     */
+    protected static final Decoration DECORATION_OUTER = Decoration.bright_blue;
+
     protected Logger getLogger() {
         return logger;
     }

--- a/src/main/java/org/fedoraproject/javapackages/validator/ElementwiseCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/ElementwiseCheck.java
@@ -3,6 +3,7 @@ package org.fedoraproject.javapackages.validator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.function.Predicate;
 
 public abstract class ElementwiseCheck<Config> extends Check<Config> {
@@ -20,10 +21,11 @@ public abstract class ElementwiseCheck<Config> extends Check<Config> {
     abstract protected Collection<String> check(Config config, RpmPathInfo rpm) throws IOException;
 
     @Override
-    public final Collection<String> check(Config config, Collection<RpmPathInfo> testRpms) throws IOException {
+    public final Collection<String> check(Config config, Iterator<RpmPathInfo> rpmIt) throws IOException {
         var result = new ArrayList<String>(0);
 
-        for (RpmPathInfo rpm : testRpms) {
+        while (rpmIt.hasNext()) {
+            RpmPathInfo rpm = rpmIt.next();
             if (filter.test(rpm)) {
                 result.addAll(check(config, rpm));
             }

--- a/src/main/java/org/fedoraproject/javapackages/validator/ElementwiseCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/ElementwiseCheck.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
+import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
+
 public abstract class ElementwiseCheck<Config> extends Check<Config> {
     private Predicate<RpmPathInfo> filter = rpm -> true;
 
@@ -28,6 +30,10 @@ public abstract class ElementwiseCheck<Config> extends Check<Config> {
             RpmPathInfo rpm = rpmIt.next();
             if (filter.test(rpm)) {
                 result.addAll(check(config, rpm));
+            } else {
+                getLogger().debug("{0}: filtered out {1}",
+                        textDecorate(getClass().getSimpleName(), Decoration.bright_yellow),
+                        textDecorate(rpm.getPath(), DECORATION_RPM));
             }
         }
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -5,8 +5,6 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -17,7 +15,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class Main {
     private static TextDecorator DECORATOR = TextDecorator.NO_DECORATOR;
     private static PrintStream debugOutputStream = new PrintStream(OutputStream.nullOutputStream(), false, StandardCharsets.UTF_8);
-    private static Collection<RpmPathInfo> TEST_RPMS = Collections.emptyList();
 
     public static TextDecorator getDecorator() {
         return DECORATOR;
@@ -26,17 +23,6 @@ public class Main {
     @SuppressFBWarnings({"MS_EXPOSE_REP"})
     public static PrintStream getDebugOutputStream() {
         return debugOutputStream;
-    }
-
-    public static void readTestRpmArgs(Iterable<String> args) {
-        Main.TEST_RPMS = new ArrayList<>();
-        for (var rpmIt = new ArgFileIterator(args); rpmIt.hasNext();) {
-            Main.TEST_RPMS.add(rpmIt.next());
-        }
-    }
-
-    public static Collection<RpmPathInfo> getTestRpms() {
-        return Collections.unmodifiableCollection(TEST_RPMS);
     }
 
     static record Flag(String... options) {

--- a/src/main/java/org/fedoraproject/javapackages/validator/RpmAttributeCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/RpmAttributeCheck.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.fedoraproject.javadeptools.rpm.RpmInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 
 public class RpmAttributeCheck<Config> extends ElementwiseCheck<Config> {
     protected RpmAttributeCheck(Class<Config> configClass) {
@@ -32,15 +31,15 @@ public class RpmAttributeCheck<Config> extends ElementwiseCheck<Config> {
                 if (!Boolean.class.cast(filter.invoke(config, rpm, attributeValue))) {
                     ok = false;
                     result.add(failMessage("{0}: Attribute {1} with invalid value: {2}",
-                            textDecorate(rpm.getPath(), Decoration.bright_red),
-                            textDecorate(attributeName, Decoration.bright_cyan),
-                            textDecorate(attributeValue, Decoration.bright_magenta)));
+                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                            textDecorate(attributeName, DECORATION_OUTER),
+                            textDecorate(attributeValue, DECORATION_ACTUAL)));
                 }
 
                 if (ok) {
                     getLogger().pass("{0}: Attribute [{1}]: ok",
-                            textDecorate(rpm.getPath(), Decoration.bright_red),
-                            textDecorate(attributeName, Decoration.bright_cyan));
+                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                            textDecorate(attributeName, DECORATION_OUTER));
                 }
             }
         } catch (ReflectiveOperationException ex) {

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/BytecodeVersionCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/BytecodeVersionCheck.java
@@ -75,10 +75,10 @@ public class BytecodeVersionCheck extends ElementwiseCheck<BytecodeVersionConfig
 
                                 if (!config.allowedVersion(rpm, jarName, className, version)) {
                                     result.add(failMessage("{0}: {1}: {2}: illegal class bytecode version {3}",
-                                            textDecorate(rpm.getPath(), Decoration.bright_red),
-                                            textDecorate(jarName, Decoration.bright_blue),
+                                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                                            textDecorate(jarName, DECORATION_OUTER),
                                             textDecorate(className, Decoration.bright_yellow),
-                                            textDecorate(version, Decoration.bright_cyan)));
+                                            textDecorate(version, DECORATION_ACTUAL)));
                                     foundVersions = null;
                                 } else if (foundVersions != null) {
                                     foundVersions.add(version);
@@ -88,9 +88,9 @@ public class BytecodeVersionCheck extends ElementwiseCheck<BytecodeVersionConfig
 
                         if (foundVersions != null) {
                             getLogger().pass("{0}: {1}: found bytecode versions: {2}",
-                                    textDecorate(rpm.getPath(), Decoration.bright_red),
-                                    textDecorate(jarName, Decoration.bright_blue),
-                                    textDecorate(foundVersions, Decoration.bright_cyan));
+                                    textDecorate(rpm.getPath(), DECORATION_RPM),
+                                    textDecorate(jarName, DECORATION_OUTER),
+                                    textDecorate(foundVersions, DECORATION_ACTUAL));
                         }
                     }
                 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheck.java
@@ -15,7 +15,6 @@ import org.fedoraproject.javadeptools.rpm.RpmInfo;
 import org.fedoraproject.javapackages.validator.Check;
 import org.fedoraproject.javapackages.validator.Common;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 import org.fedoraproject.javapackages.validator.config.DuplicateFileConfig;
 
 /**
@@ -65,8 +64,8 @@ public class DuplicateFileCheck extends Check<DuplicateFileConfig> {
                 // If the file entry is a directory in all providers, then it is ok
                 boolean okDirectory = entry.getValue().stream().map(Pair::getKey).allMatch(CpioArchiveEntry::isDirectory);
 
-                String decoratedFile = textDecorate(entry.getKey(), Decoration.bright_cyan);
-                String decoratedProviders = entry.getValue().stream().map(pair -> textDecorate(pair.getValue(), Decoration.bright_red)).toList().toString();
+                String decoratedFile = textDecorate(entry.getKey(), DECORATION_ACTUAL);
+                String decoratedProviders = entry.getValue().stream().map(pair -> textDecorate(pair.getValue(), DECORATION_RPM)).toList().toString();
                 if (okDifferentArchs[0]) {
                     getLogger().info("File {0} provided by RPMs of unique architectures: {1}",
                             decoratedFile, decoratedProviders);

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheck.java
@@ -5,9 +5,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.TreeMap;
 
 import org.apache.commons.compress.archivers.cpio.CpioArchiveEntry;
+import org.apache.commons.compress.utils.Iterators;
 import org.apache.commons.lang3.tuple.Pair;
 import org.fedoraproject.javadeptools.rpm.RpmInfo;
 import org.fedoraproject.javapackages.validator.Check;
@@ -25,7 +27,10 @@ public class DuplicateFileCheck extends Check<DuplicateFileConfig> {
     }
 
     @Override
-    public Collection<String> check(DuplicateFileConfig config, Collection<RpmPathInfo> testRpms) throws IOException {
+    public Collection<String> check(DuplicateFileConfig config, Iterator<RpmPathInfo> rpmIt) throws IOException {
+        var testRpms = new ArrayList<RpmPathInfo>();
+        Iterators.addAll(testRpms, rpmIt);
+
         var result = new ArrayList<String>(0);
 
         // The union of file paths present in all RPM files mapped to the RPM file names they are present in

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/FilesCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/FilesCheck.java
@@ -10,7 +10,6 @@ import org.fedoraproject.javadeptools.rpm.RpmArchiveInputStream;
 import org.fedoraproject.javapackages.validator.Common;
 import org.fedoraproject.javapackages.validator.ElementwiseCheck;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 import org.fedoraproject.javapackages.validator.config.FilesConfig;
 
 public class FilesCheck extends ElementwiseCheck<FilesConfig> {
@@ -29,13 +28,13 @@ public class FilesCheck extends ElementwiseCheck<FilesConfig> {
 
                 if (!config.allowedFile(rpm, entryName)) {
                     result.add(failMessage("{0}: Illegal file: {1}",
-                            textDecorate(rpm.getPath(), Decoration.bright_red),
-                            textDecorate(entryName, Decoration.bright_blue)));
+                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                            textDecorate(entryName, DECORATION_ACTUAL)));
                 }
             }
 
             if (previousSize == result.size()) {
-                getLogger().pass("{0}: ok", textDecorate(rpm.getPath(), Decoration.bright_red));
+                getLogger().pass("{0}: ok", textDecorate(rpm.getPath(), DECORATION_RPM));
             }
         }
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/JavaExclusiveArchCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/JavaExclusiveArchCheck.java
@@ -9,7 +9,6 @@ import org.fedoraproject.javadeptools.rpm.RpmInfo;
 import org.fedoraproject.javapackages.validator.Check;
 import org.fedoraproject.javapackages.validator.ElementwiseCheck;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 
 public class JavaExclusiveArchCheck extends ElementwiseCheck<Check.NoConfig> {
     /**
@@ -25,7 +24,7 @@ public class JavaExclusiveArchCheck extends ElementwiseCheck<Check.NoConfig> {
     @Override
     protected Collection<String> check(Check.NoConfig config, RpmPathInfo rpm) throws IOException {
         var result = new ArrayList<String>(0);
-        String decoratedRpm = textDecorate(rpm.getPath(), Decoration.bright_red);
+        String decoratedRpm = textDecorate(rpm.getPath(), DECORATION_RPM);
 
         boolean noarch = rpm.getBuildArchs().equals(Collections.singletonList("noarch"));
         String expected = noarch ? JAVA_ARCHES + " noarch" : JAVA_ARCHES;
@@ -35,8 +34,8 @@ public class JavaExclusiveArchCheck extends ElementwiseCheck<Check.NoConfig> {
             getLogger().pass("{0}: ExclusiveArch with %java_arches - ok", decoratedRpm);
         } else {
             result.add(failMessage("{0}: expected ExclusiveArch \"{1}\" but was \"{2}\"",
-                    decoratedRpm, textDecorate(expected, Decoration.bright_magenta),
-                    textDecorate(actual, Decoration.bright_magenta)));
+                    decoratedRpm, textDecorate(expected, DECORATION_EXPECTED),
+                    textDecorate(actual, DECORATION_ACTUAL)));
         }
 
         return result;

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/JavadocNoarchCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/JavadocNoarchCheck.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import org.fedoraproject.javapackages.validator.Check;
 import org.fedoraproject.javapackages.validator.ElementwiseCheck;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 
 public class JavadocNoarchCheck extends ElementwiseCheck<Check.NoConfig> {
     public JavadocNoarchCheck() {
@@ -21,12 +20,12 @@ public class JavadocNoarchCheck extends ElementwiseCheck<Check.NoConfig> {
 
         if (!"noarch".equals(rpm.getArch())) {
             result.add(failMessage("{0} is a javadoc package but its architecture is {1}",
-                    textDecorate(rpm.getPath(), Decoration.bright_red),
-                    textDecorate(rpm.getArch(), Decoration.bright_magenta)));
+                    textDecorate(rpm.getPath(), DECORATION_RPM),
+                    textDecorate(rpm.getArch(), DECORATION_ACTUAL)));
         } else {
             getLogger().pass("{0} is a javadoc package and its architecture is {1}",
-                    textDecorate(rpm.getPath(), Decoration.bright_red),
-                    textDecorate("noarch", Decoration.bright_cyan));
+                    textDecorate(rpm.getPath(), DECORATION_RPM),
+                    textDecorate("noarch", DECORATION_ACTUAL));
         }
 
         return result;

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/RpmFilesizeCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/RpmFilesizeCheck.java
@@ -9,7 +9,6 @@ import java.util.Locale;
 
 import org.fedoraproject.javapackages.validator.ElementwiseCheck;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 import org.fedoraproject.javapackages.validator.config.RpmFilesizeConfig;
 
 public class RpmFilesizeCheck extends ElementwiseCheck<RpmFilesizeConfig> {
@@ -26,12 +25,12 @@ public class RpmFilesizeCheck extends ElementwiseCheck<RpmFilesizeConfig> {
 
         if (!config.allowedFilesize(rpm, filesize)) {
             result.add(failMessage("{0}: file size is: {1} bytes",
-                    textDecorate(rpm.getPath(), Decoration.bright_red),
-                    textDecorate(formattedFilesize, Decoration.bright_cyan)));
+                    textDecorate(rpm.getPath(), DECORATION_RPM),
+                    textDecorate(formattedFilesize, DECORATION_ACTUAL)));
         } else {
             getLogger().pass("{0}: file size is: {1} bytes",
-                    textDecorate(rpm.getPath(), Decoration.bright_red),
-                    textDecorate(formattedFilesize, Decoration.bright_cyan));
+                    textDecorate(rpm.getPath(), DECORATION_RPM),
+                    textDecorate(formattedFilesize, DECORATION_ACTUAL));
         }
 
         return result;

--- a/src/main/java/org/fedoraproject/javapackages/validator/checks/SymlinkCheck.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/checks/SymlinkCheck.java
@@ -10,7 +10,7 @@ import org.fedoraproject.javadeptools.rpm.RpmInfo;
 import org.fedoraproject.javapackages.validator.Common;
 import org.fedoraproject.javapackages.validator.ElementwiseCheck;
 import org.fedoraproject.javapackages.validator.RpmPathInfo;
-import org.fedoraproject.javapackages.validator.TextDecorator;
+import org.fedoraproject.javapackages.validator.TextDecorator.Decoration;
 import org.fedoraproject.javapackages.validator.config.SymlinkConfig;
 
 /**
@@ -38,17 +38,17 @@ public class SymlinkCheck extends ElementwiseCheck<SymlinkConfig> {
 
                 if (location == null) {
                     result.add(failMessage("{0}: Link {1} points to {2} (normalized as {3}) which was not found",
-                            textDecorate(rpm.getPath(), TextDecorator.Decoration.bright_red),
-                            textDecorate(link, TextDecorator.Decoration.bright_cyan),
-                            textDecorate(target, TextDecorator.Decoration.bright_magenta),
-                            textDecorate(target.normalize(), TextDecorator.Decoration.magenta)));
+                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                            textDecorate(link, Decoration.bright_cyan),
+                            textDecorate(target, Decoration.bright_magenta),
+                            textDecorate(target.normalize(), Decoration.magenta)));
                 } else {
                     getLogger().pass("{0}: Link {1} points to {2} (normalized as {3}) located in {4}",
-                            textDecorate(rpm.getPath(), TextDecorator.Decoration.bright_red),
-                            textDecorate(link, TextDecorator.Decoration.bright_cyan),
-                            textDecorate(target, TextDecorator.Decoration.bright_magenta),
-                            textDecorate(target.normalize(), TextDecorator.Decoration.magenta),
-                            textDecorate(location, TextDecorator.Decoration.bright_blue));
+                            textDecorate(rpm.getPath(), DECORATION_RPM),
+                            textDecorate(link, Decoration.bright_cyan),
+                            textDecorate(target, Decoration.bright_magenta),
+                            textDecorate(target.normalize(), Decoration.magenta),
+                            textDecorate(location, DECORATION_OUTER));
                 }
             }
         }

--- a/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.stream.Stream;
 
 public class TestCommon {
@@ -12,13 +12,13 @@ public class TestCommon {
     public static final Path RPM_PATH_PREFIX = RPMBUILD_PATH_PREFIX.resolve(Paths.get("RPMS"));
     public static final Path SRPM_PATH_PREFIX = RPMBUILD_PATH_PREFIX.resolve(Paths.get("SRPMS"));
 
-    public static Collection<RpmPathInfo> collectionFrom(Stream<Path> paths) {
+    public static Iterator<RpmPathInfo> iteratorFrom(Stream<Path> paths) {
         return paths.map(path -> {
             try {
                 return new RpmPathInfo(path);
             } catch (IOException ex) {
                 throw new UncheckedIOException(ex);
             }
-        }).toList();
+        }).iterator();
     }
 }

--- a/src/test/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheckTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/checks/DuplicateFileCheckTest.java
@@ -16,7 +16,7 @@ public class DuplicateFileCheckTest {
 
     @Test
     void testIllegalDuplicateFile() throws IOException {
-        var result = new DuplicateFileCheck().check(null, TestCommon.collectionFrom(Stream.of(
+        var result = new DuplicateFileCheck().check(null, TestCommon.iteratorFrom(Stream.of(
                 DUPLICATE_FILE1_RPM, DUPLICATE_FILE2_RPM)));
         assertEquals(1, result.size());
     }
@@ -24,7 +24,7 @@ public class DuplicateFileCheckTest {
     @Test
     void testAllowedDuplicateFile() throws IOException {
         var result = new DuplicateFileCheck().check((filename, providerRpms) -> true,
-                TestCommon.collectionFrom(Stream.of(DUPLICATE_FILE1_RPM, DUPLICATE_FILE2_RPM)));
+                TestCommon.iteratorFrom(Stream.of(DUPLICATE_FILE1_RPM, DUPLICATE_FILE2_RPM)));
         assertEquals(0, result.size());
     }
 }

--- a/src/test/java/org/fedoraproject/javapackages/validator/checks/JavaExclusiveArchCheckTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/checks/JavaExclusiveArchCheckTest.java
@@ -18,25 +18,25 @@ public class JavaExclusiveArchCheckTest {
 
     @Test
     public void testAllowedExclusiveArchArchful() throws IOException {
-        var result = new JavaExclusiveArchCheck().check(null, TestCommon.collectionFrom(Stream.of(EA_ARCHFUL)));
+        var result = new JavaExclusiveArchCheck().check(null, TestCommon.iteratorFrom(Stream.of(EA_ARCHFUL)));
         assertEquals(0, result.size());
     }
 
     @Test
     public void testAllowedExclusiveArchNoarch() throws IOException {
-        var result = new JavaExclusiveArchCheck().check(null, TestCommon.collectionFrom(Stream.of(EA_NOARCH)));
+        var result = new JavaExclusiveArchCheck().check(null, TestCommon.iteratorFrom(Stream.of(EA_NOARCH)));
         assertEquals(0, result.size());
     }
 
     @Test
     public void testExclusiveArchMissingNoarch() throws IOException {
-        var result = new JavaExclusiveArchCheck().check(null, TestCommon.collectionFrom(Stream.of(EA_ARCHFUL_MISSING)));
+        var result = new JavaExclusiveArchCheck().check(null, TestCommon.iteratorFrom(Stream.of(EA_ARCHFUL_MISSING)));
         assertEquals(1, result.size());
     }
 
     @Test
     public void testIllegalExclusiveArchAdditionalNoarch() throws IOException {
-        var result = new JavaExclusiveArchCheck().check(null, TestCommon.collectionFrom(Stream.of(EA_ARCHFUL_NOARCH)));
+        var result = new JavaExclusiveArchCheck().check(null, TestCommon.iteratorFrom(Stream.of(EA_ARCHFUL_NOARCH)));
         assertEquals(1, result.size());
     }
 }

--- a/src/test/java/org/fedoraproject/javapackages/validator/checks/JavadocNoarchCheckTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/checks/JavadocNoarchCheckTest.java
@@ -19,28 +19,28 @@ public class JavadocNoarchCheckTest {
     @Test
     void testIllegalArchfulJavadoc() throws IOException {
         var result = new JavadocNoarchCheck().check(null,
-                TestCommon.collectionFrom(Stream.of(ARCH_ARCH_RPM)));
+                TestCommon.iteratorFrom(Stream.of(ARCH_ARCH_RPM)));
         assertEquals(1, result.size());
     }
 
     @Test
     void testAllowedNoarchJavadocArchfulPackage() throws IOException {
         var result = new JavadocNoarchCheck().check(null,
-                TestCommon.collectionFrom(Stream.of(ARCH_NOARCH_RPM)));
+                TestCommon.iteratorFrom(Stream.of(ARCH_NOARCH_RPM)));
         assertEquals(0, result.size());
     }
 
     @Test
     void testAllowedNoarchJavadocNoarchPackage() throws IOException {
         var result = new JavadocNoarchCheck().check(null,
-                TestCommon.collectionFrom(Stream.of(NOARCH_NOARCH_RPM)));
+                TestCommon.iteratorFrom(Stream.of(NOARCH_NOARCH_RPM)));
         assertEquals(0, result.size());
     }
 
     @Test
     void testIgnoreNonJavadoc() throws IOException {
         var result = new JavadocNoarchCheck().check(null,
-                TestCommon.collectionFrom(Stream.of(NON_JAVADOC_RPM)));
+                TestCommon.iteratorFrom(Stream.of(NON_JAVADOC_RPM)));
         assertEquals(0, result.size());
     }
 }

--- a/src/test/java/org/fedoraproject/javapackages/validator/checks/SymlinkCheckTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/checks/SymlinkCheckTest.java
@@ -18,14 +18,14 @@ public class SymlinkCheckTest {
     @Test
     void testDanglingSymlink() throws IOException {
         var result = new SymlinkCheck().check(new SymlinkConfig.EnvrootImpl(Paths.get("/")),
-                TestCommon.collectionFrom(Stream.of(DANGLING_SYMLINK_RPM)));
+                TestCommon.iteratorFrom(Stream.of(DANGLING_SYMLINK_RPM)));
         assertEquals(1, result.size());
     }
 
     @Test
     void testValidSymlink() throws IOException {
         var result = new SymlinkCheck().check(new SymlinkConfig.EnvrootImpl(Paths.get("/")),
-                TestCommon.collectionFrom(Stream.of(VALID_SYMLINK_RPM)));
+                TestCommon.iteratorFrom(Stream.of(VALID_SYMLINK_RPM)));
         assertEquals(0, result.size());
     }
 }


### PR DESCRIPTION
Removed `Main.getTestRpms`, because the only consumer stopped needing them. I don't want to keep them accessible unless there is a reason to.