### PR TITLE
Remove conditionals from NVRJarMetadataValidator and disable it by de…

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/DefaultValidatorFactory.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/DefaultValidatorFactory.java
@@ -15,7 +15,7 @@ public class DefaultValidatorFactory implements ValidatorFactory {
                 new JavaExclusiveArchValidator(),
                 // new JpmsProvidesValidator(),
                 new MavenMetadataValidator(),
-                new NVRJarMetadataValidator(),
+                // new NVRJarMetadataValidator(),
         });
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/NVRJarMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/NVRJarMetadataValidator.java
@@ -120,27 +120,16 @@ public class NVRJarMetadataValidator extends DefaultValidator {
     @Override
     public void validate(Iterable<RpmPackage> rpms) throws Exception {
         for (var rpm : rpms) {
-            var release = rpm.getInfo().getRelease();
-            int i = 0;
-            while (release.charAt(i) != '.') {
-                ++i;
-            }
-
-            // We only care about EL packages
-            if (release.substring(i + 1).startsWith("el")) {
-                if (rpm.getInfo().isSourcePackage()) {
-                    var filename = rpm.getPath().getFileName();
-                    if (filename == null) {
-                        error("{0}: Could not obtain the path from URL: {1}",
-                                Decorated.rpm(rpm), Decorated.actual(rpm.getPath()));
-                        return;
-                    }
-                    this.rpms.computeIfAbsent(filename.toString(), name -> new RpmEntry()).sourceRpm = rpm;
-                } else {
-                    this.rpms.computeIfAbsent(rpm.getInfo().getSourceRPM(), name -> new RpmEntry()).binaryRpms.add(rpm);
+            if (rpm.getInfo().isSourcePackage()) {
+                var filename = rpm.getPath().getFileName();
+                if (filename == null) {
+                    error("{0}: Could not obtain the path from URL: {1}",
+                            Decorated.rpm(rpm), Decorated.actual(rpm.getPath()));
+                    return;
                 }
+                this.rpms.computeIfAbsent(filename.toString(), name -> new RpmEntry()).sourceRpm = rpm;
             } else {
-                skip("Ignoring {0}", Decorated.rpm(rpm));
+                this.rpms.computeIfAbsent(rpm.getInfo().getSourceRPM(), name -> new RpmEntry()).binaryRpms.add(rpm);
             }
         }
 


### PR DESCRIPTION
…fault

NVRJarMetadataValidator used to detect the release of the RPM package to decide if it will be executed or skipped. The matching code was fragile.
After differentiating the test branches in the test repository, this matching is no longer required.