### PR TITLE
Allow creating MainTmt without env variables

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -44,9 +44,15 @@ public class MainTmt extends Main {
     }
 
     public static Main create() {
+        var tmtTestData = Paths.get(getenv("TMT_TEST_DATA"));
+        var tmtTree = Paths.get(getenv("TMT_TREE"));
+        return create(tmtTestData, tmtTree);
+    }
+
+    public static Main create(Path tmtTestData, Path tmtTree) {
         var result = new MainTmt();
-        result.TMT_TEST_DATA = Paths.get(getenv("TMT_TEST_DATA"));
-        result.TMT_TREE = Paths.get(getenv("TMT_TREE"));
+        result.TMT_TEST_DATA = tmtTestData;
+        result.TMT_TREE = tmtTree;
         return result;
     }
 


### PR DESCRIPTION
When testing MainTmt it is useful to programatically create it from Java code and pass values of TMT_TEST_DATA and TMT_TREE directly, without using system environment.