### PR TITLE
Avoid expanding dependency/ directory when it doesn't exist

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -316,7 +316,7 @@ public class Main {
         var expandedClassPaths = new ArrayList<Path>();
         for (var classPath : parameters.classPaths) {
             var cpParent = classPath.getParent();
-            if (classPath.endsWith("*") && cpParent != null) {
+            if (classPath.endsWith("*") && cpParent != null && Files.isDirectory(cpParent)) {
                 try (var list = Files.list(cpParent).filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".jar"))) {
                     list.forEach(expandedClassPaths::add);
                 }


### PR DESCRIPTION
The dependency/ directory may be absent.  In this case don't try to list files in it.