### PR TITLE
Upon crash write results.yaml with crash.log

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -294,6 +294,30 @@ public class MainTmt extends Main {
         return TMT_TEST_DATA.resolve(path);
     }
 
+    private void writeCrashLog(Throwable t) throws IOException {
+        try (var os = Files.newOutputStream(TMT_TEST_DATA.resolve("results.yaml"));
+                PrintStream ps = new PrintStream(os, true, StandardCharsets.UTF_8)) {
+            ps.println("- name: /");
+            ps.println("  result: error");
+            ps.println("  log:");
+            ps.println("   - crash.log");
+        }
+        try (var os = Files.newOutputStream(TMT_TEST_DATA.resolve("crash.log"));
+                PrintStream ps = new PrintStream(os, true, StandardCharsets.UTF_8)) {
+            t.printStackTrace(ps);
+        }
+    }
+
+    @Override
+    public int run(String[] args) throws Exception {
+        try {
+            return super.run(args);
+        } catch (Throwable t) {
+            writeCrashLog(t);
+            return 2;
+        }
+    }
+
     public static void main(String[] args) throws Exception {
         create().run(args);
     }

--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -44,9 +44,15 @@ public class MainTmt extends Main {
     }
 
     public static Main create() {
+        var tmtTestData = Paths.get(getenv("TMT_TEST_DATA"));
+        var tmtTree = Paths.get(getenv("TMT_TREE"));
+        return create(tmtTestData, tmtTree);
+    }
+
+    public static Main create(Path tmtTestData, Path tmtTree) {
         var result = new MainTmt();
-        result.TMT_TEST_DATA = Paths.get(getenv("TMT_TEST_DATA"));
-        result.TMT_TREE = Paths.get(getenv("TMT_TREE"));
+        result.TMT_TEST_DATA = tmtTestData;
+        result.TMT_TREE = tmtTree;
         return result;
     }
 

--- a/src/test/java/org/fedoraproject/javapackages/validator/MainTmtTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/MainTmtTest.java
@@ -1,0 +1,44 @@
+package org.fedoraproject.javapackages.validator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MainTmtTest {
+
+    @TempDir
+    Path tmtTree;
+    @TempDir
+    Path tmtTestData;
+    @TempDir
+    Path artifactsDir;
+
+    @Test
+    void testCrashLog() throws Exception {
+        Main main = MainTmt.create(tmtTestData, tmtTree);
+
+        List<String> args = new ArrayList<>();
+        args.add("-x");
+        args.add("-f");
+        args.add(artifactsDir.toString());
+
+        Files.createFile(artifactsDir.resolve("empty.rpm"));
+
+        int rc = main.run(args.toArray(new String[args.size()]));
+
+        assertEquals(2, rc, "Correct exit code");
+        assertTrue(Files.isRegularFile(tmtTestData.resolve("results.yaml")), "results.yaml is present");
+        assertTrue(Files.isRegularFile(tmtTestData.resolve("crash.log")), "crash.log is present");
+
+        assertTrue(Files.readString(tmtTestData.resolve("results.yaml")).contains("result: error"), "result is error");
+        assertTrue(Files.readString(tmtTestData.resolve("crash.log"))
+                .contains("java.io.IOException: Unable to open RPM file"), "crash.log contains stack trace");
+    }
+
+}


### PR DESCRIPTION
When JPV itself crashes with an exception it should still write results.yaml with error result containing exception stack trace.