### PR TITLE
Improve Maven metadata validation

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
@@ -104,10 +104,10 @@ public class MavenMetadataValidator extends ElementwiseValidator {
                     Decorated.rpm(rpm),
                     Decorated.actual(jar));
         }
-        for (var jar : pomsWithoutMd) {
-            fail("{0}: POM file without corresponding Maven metadata: {1}",
+        for (var pom : pomsWithoutMd) {
+            info("{0}: POM file without corresponding Maven metadata: {1}",
                     Decorated.rpm(rpm),
-                    Decorated.actual(jar));
+                    Decorated.actual(pom));
         }
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
@@ -62,7 +62,7 @@ public class MavenMetadataValidator extends ElementwiseValidator {
         }
 
         var jarsWithoutMd = foundFiles.stream()
-                .filter(f -> f.startsWith("/usr/share/java/"))
+                .filter(f -> f.startsWith("/usr/share/java/") || f.startsWith("/usr/lib/java/"))
                 .filter(f -> f.endsWith(".jar"))
                 .collect(Collectors.toSet());
         var pomsWithoutMd = foundFiles.stream()

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
@@ -57,7 +57,7 @@ public class MavenMetadataValidator extends ElementwiseValidator {
         }
 
         if (metadataXmls.isEmpty()) {
-            info("{0}: maven metadata XML file not found", Decorated.rpm(rpm));
+            skip("{0}: maven metadata XML file not found", Decorated.rpm(rpm));
             return;
         }
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
@@ -65,6 +65,10 @@ public class MavenMetadataValidator extends ElementwiseValidator {
                 .filter(f -> f.startsWith("/usr/share/java/"))
                 .filter(f -> f.endsWith(".jar"))
                 .collect(Collectors.toSet());
+        var pomsWithoutMd = foundFiles.stream()
+                .filter(f -> f.startsWith("/usr/share/maven-poms/"))
+                .filter(f -> f.endsWith(".pom"))
+                .collect(Collectors.toSet());
 
         for (var entry : metadataXmls) {
             PackageMetadata packageMetadata = null;
@@ -80,6 +84,7 @@ public class MavenMetadataValidator extends ElementwiseValidator {
                 var artifactPath = Paths.get(artifact.getPath());
                 var metadataXml = Common.getEntryPath(entry.getKey());
                 jarsWithoutMd.remove(artifactPath.toString());
+                pomsWithoutMd.remove(artifactPath.toString());
                 if (foundFiles.contains(artifactPath.toString())) {
                     pass("{0}: {1}: artifact {2} is present in the RPM",
                             Decorated.rpm(rpm),
@@ -96,6 +101,11 @@ public class MavenMetadataValidator extends ElementwiseValidator {
 
         for (var jar : jarsWithoutMd) {
             info("{0}: JAR file without corresponding Maven metadata: {1}",
+                    Decorated.rpm(rpm),
+                    Decorated.actual(jar));
+        }
+        for (var jar : pomsWithoutMd) {
+            fail("{0}: POM file without corresponding Maven metadata: {1}",
                     Decorated.rpm(rpm),
                     Decorated.actual(jar));
         }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/MavenMetadataValidator.java
@@ -23,10 +23,18 @@ import io.kojan.javadeptools.rpm.RpmInfo;
 import io.kojan.javadeptools.rpm.RpmPackage;
 
 /**
- * Validator which checks that maven metadata XML file references files
- * present on the file system relative to the environment root.
+ * Validator which checks that Maven metadata XML stored in
+ * {@code /usr/share/maven-metadata/}.
+ * <p>
+ * It checks whether:
+ * <ul>
+ * <li>the metadata files can be parsed with XMvn,
+ * <li>all artifacts mentioned in the metadata are actually included as files in
+ * the package,
+ * <li>there are no JARs and POMs without Maven metadata.
+ * </ul>
  *
- * Ignores source rpms.
+ * Ignores source RPMs.
  */
 @SuppressFBWarnings({"DMI_HARDCODED_ABSOLUTE_FILENAME"})
 public class MavenMetadataValidator extends ElementwiseValidator {


### PR DESCRIPTION
Packages without Maven metadata are perfectly fine, so we should not bother users to check them by using "info" result. Instead, use the "skip" result.
Also check for JARs and POMs without Maven metadata.
To be backwards-compatible with older Fedora branches, for now don't fail when there are JARs and POMs without metadata, but "info" instead.
Fixes #88 