### PR TITLE
Make javadocs buildable

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -5,10 +5,10 @@ WORKDIR "/usr/local/src/javapackages-validator"
 
 # First fetch dependencies without having sources
 COPY "pom.xml" "/usr/local/src/javapackages-validator/"
-RUN mvn -B clean install
+RUN mvn -B clean install javadoc:javadoc
 
 COPY "src/" "/usr/local/src/javapackages-validator/src/"
-RUN mvn -B clean install
+RUN mvn -B clean install javadoc:javadoc
 
 ################################################################################
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/Common.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/Common.java
@@ -27,7 +27,7 @@ public class Common {
     }
 
     /**
-     * @param rpm The rpm file to inspect.
+     * @param rpm The RPM package to inspect
      * @return A map of file paths mapped to either the target of the symlink
      * or null, if the file path is not a symlink.
      * @throws IOException


### PR DESCRIPTION
Also add javadoc step to CI to ensure javadocs remain buildable.

Fixes #91