### PR TITLE
Update documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,7 +67,7 @@ Recompilation is caused by any of these conditions:
 Recompilation causes the class path directory to be cleaned before the newly compiled classes are placed there.
 
 === Service file
-The file `META-INF/services/org.fedoraproject.javapackages.validator.Validator` contains a line-separated list of validator class names which are available to be executed.
+The file `META-INF/services/org.fedoraproject.javapackages.validator.spi.ValidatorFactory` contains a line-separated list of validator factory class names which are available to be executed.
 This file will be copied from the source path to the class path and is expected to be present on the class path if source path is not specified.
 
 The validator main argument passed to javapackages-validator must exactly match one of the names listed in either the service file or the service file on the built-in class path.

--- a/README.adoc
+++ b/README.adoc
@@ -72,23 +72,23 @@ This file will be copied from the source path to the class path and is expected 
 
 The validator main argument passed to javapackages-validator must exactly match one of the names listed in either the service file or the service file on the built-in class path.
 
-=== TMT
-The tool contains another main class `MainTmt` which is intended to be invoked from within Tmt tests.
-When the validator is run from the Tmt entry point, it requires the environment variables `TMT_TEST_DATA` and `TMT_TREE` to be defined.
+=== tmt
+The tool contains another main class `MainTmt` which is intended to be invoked from within tmt tests.
+When the validator is run from the tmt entry point, it requires the environment variables `TMT_TEST_DATA` and `TMT_TREE` to be defined.
 
 Test execution from this entry point is configured using a configuration file named `javapackages-validator.yaml`.
 This file can be located either in the root, i.e. the value of the `TMT_TREE` variable or in the `plans` directory of the project.
 
 Every validator has an associated _test name_.
 This is the result of the virtual `getTestName` function.
-This name must be in the format of TMT tests, i.e. starting with `/`.
+This name must be in the format of tmt tests, i.e. starting with `/`.
 Test names are used to create report files.
 
 ==== Configuration
 The following fields are allowed in the YAML configuration file.
 
 _Fields starting with_ `/`::
-The key is a Tmt test name. The value of the field must be a list of strings. It will be passed as the arguments to the according validator.
+The key is a tmt test name. The value of the field must be a list of strings. It will be passed as the arguments to the according validator.
 
 `exclude-tests-matching`::
 The value of this field is a list of strings.
@@ -128,7 +128,7 @@ The validator is supposed to call functions `debug`, `info`, `pass`, `fail`, `er
 For details, see the section <<_result_states>>.
 
 `String getTestName()`::
-This is used to obtain the TMT test name. See also the `TmtTest` annotation class.
+This is used to obtain the tmt test name. See also the `TmtTest` annotation class.
 
 [#_result_states]
 === Result states

--- a/README.adoc
+++ b/README.adoc
@@ -151,8 +151,7 @@ Validation was run successfully and all the checks that were executed passed.
 The validator found a potential issue which does not affect validation results, but might be worth checking and fixing.
 
 `warn`::
-The validator only produced warning information.
-Currently mostly unused.
+The validator found an issue that might be a false-positive and therefore requires further human review.
 
 `fail`::
 At least one check failed.

--- a/README.adoc
+++ b/README.adoc
@@ -114,10 +114,6 @@ Project is built with Maven. Simply run:
 $ mvn install
 ----
 
-The project currently requires a https://github.com/mkoncek/java-deptools-native[custom fork] of the _java-deptools-native_ project.
-
-In order to build this project you need to build and install this forked project also with Maven.
-
 == Custom validators
 A custom validator must inherit from the `org.fedoraproject.javapackages.validator.Validator` class and have its name listed in the service file on the class path of the program.
 Custom validators can override functions:

--- a/README.adoc
+++ b/README.adoc
@@ -133,23 +133,29 @@ This is used to obtain the tmt test name. See also the `TmtTest` annotation clas
 [#_result_states]
 === Result states
 Each validator has a single result state.
-The starting state is `info`.
+The starting state is `skip`.
 The state is overriden by calling corresponding methods of the `Validator` class.
 The state listed lower in the following hierarchy overrides the previous states but not vice-versa.
 Note that `debug` is not a result state, it only serves for the validator to provide verbose info.
 
 .Result states
 [horizontal]
-`info`::
-Validator provided some informational message.
-For example the values of some attributes of the RPM.
-This can also mean that the property being tested was not present in the RPM.
+`skip`::
+A check was expectedly skipped because the validator determined so.
+This can also mean that the property being tested was not present in the RPM under test.
 
 `pass`::
-RPM passed the validator checks.
+Validation was run successfully and all the checks that were executed passed.
+
+`info`::
+The validator found a potential issue which does not affect validation results, but might be worth checking and fixing.
+
+`warn`::
+The validator only produced warning information.
+Currently mostly unused.
 
 `fail`::
-RPM failed at at least one check.
+At least one check failed.
 
 `error`::
 An error occured, for example invalid input or an unexpected state.


### PR DESCRIPTION
Several improvements to README.adoc:
- Custom fork of java-deptools-native is no longer needed.
- Fix service file names in README.adoc.
- It's tmt, not TMT, not Tmt.
- Update docs about result states.
