### PR TITLE
Fix line breaks missing from the HTML output

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/HtmlDecorator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/HtmlDecorator.java
@@ -2,7 +2,6 @@ package org.fedoraproject.javapackages.validator;
 
 import java.util.Objects;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.fedoraproject.javapackages.validator.spi.Decorated;
 import org.fedoraproject.javapackages.validator.spi.Decoration;
 
@@ -23,7 +22,7 @@ class HtmlDecorator implements TextDecorator {
         }
 
         result.append("\">");
-        result.append(StringEscapeUtils.escapeHtml4(Objects.toString(decorated.getObject())).replace(System.lineSeparator(), "<br>"));
+        result.append(Objects.toString(decorated.getObject()));
         result.append("</text>");
 
         return result.toString();

--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -22,6 +22,7 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.IterableUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.fedoraproject.javapackages.validator.spi.Decorated;
 import org.fedoraproject.javapackages.validator.spi.LogEntry;
 import org.fedoraproject.javapackages.validator.spi.LogEvent;
@@ -103,7 +104,9 @@ public class MainTmt extends Main {
         public void printRow(LogEntry entry) {
             println("  <tr class=\"" + entry.kind() + "\">");
             println("    <td>" + HtmlDecorator.INSTANCE.decorate(entry.kind().getDecorated()) + "</td>");
-            println("    <td>" + Main.decoratedObjects(entry, HtmlDecorator.INSTANCE) + "</td>");
+            var text = Main.decoratedObjects(entry, HtmlDecorator.INSTANCE);
+            text = StringEscapeUtils.escapeHtml4(text).replace(System.lineSeparator(), "<br>");
+            println("    <td>" + text + "</td>");
             println("  </tr>");
         }
 

--- a/src/test/java/org/fedoraproject/javapackages/validator/MainTmtTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/MainTmtTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class MainTmtTest {
-
     @TempDir
     Path tmtTree;
     @TempDir
@@ -83,7 +82,6 @@ class MainTmtTest {
 
     @Test
     void testCrashLog() throws Exception {
-
         // Corrupted empty file triggers the crash
         Files.createFile(artifactsDir.resolve("empty.rpm"));
 
@@ -96,7 +94,6 @@ class MainTmtTest {
     }
 
     @Test
-    @Disabled("https://github.com/fedora-java/javapackages-validator/issues/82")
     void testHtmlNewLine() throws Exception {
         copyResources(artifactsDir, "arg_file_iterator/dangling-symlink-1-1.noarch.rpm");
 


### PR DESCRIPTION
The HTML decorator would only escape the inner contents of the Decorated class, not the whole text which is still inside a `<text>` block.

Resolves: #82