### PR TITLE
Switch to Java 22

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:21-jdk-ubi9-minimal AS builder
+FROM docker.io/library/eclipse-temurin:22-jdk-ubi9-minimal AS builder
 RUN microdnf -y install git-core maven rpm-libs
 
 WORKDIR "/usr/local/src/javapackages-validator"
@@ -8,15 +8,15 @@ COPY "pom.xml" "/usr/local/src/javapackages-validator/"
 RUN mvn -B clean install javadoc:javadoc
 
 COPY "src/" "/usr/local/src/javapackages-validator/src/"
-RUN mvn -B clean install javadoc:javadoc
+RUN mvn -B -U clean install javadoc:javadoc
 
 ################################################################################
 
-FROM docker.io/library/eclipse-temurin:21-jdk-ubi9-minimal
+FROM docker.io/library/eclipse-temurin:22-jdk-ubi9-minimal
 RUN microdnf -y update
 RUN microdnf -y install rpm-libs
 
 COPY --from=builder "/usr/local/src/javapackages-validator/target/dependency/" "/opt/javapackages-validator/dependency/"
 COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"
 
-ENTRYPOINT ["/opt/java/openjdk/bin/java", "--enable-preview", "--enable-native-access", "ALL-UNNAMED", "-cp", "/opt/javapackages-validator/validator.jar"]
+ENTRYPOINT ["/opt/java/openjdk/bin/java", "--enable-native-access", "ALL-UNNAMED", "-cp", "/opt/javapackages-validator/validator.jar"]

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ _Javapackages-validator_ is a tool used to test RPM files.
 It executes checks implemented as Java classes over the set of provided RPM files.
 
 == Building
-The project is built with Maven. JDK of version 21 is required. Simply run:
+The project is built with Maven. JDK of version 22 is required. Simply run:
 [source, shell]
 ----
 $ mvn install
@@ -14,7 +14,7 @@ $ mvn install
 
 == Usage
 The tool is executed from command line using `java` command with the proper class path.
-JVM of version 21 is required.
+JVM of version 22 is required.
 
 [subs = quotes]
 ----
@@ -22,8 +22,8 @@ Main [_optional flags_] <_main arguments_>... [-f _RPM files or directories to t
 ----
 
 [NOTE]
-Due to the usage of the Foreign Memory Accesss feature, JVM arguments must include: +
-`--enable-preview --enable-native-access ALL-UNNAMED`.
+Due to the usage of the [Foreign Memory Accesss](https://openjdk.org/jeps/454) feature, JVM arguments must include: +
+`--enable-native-access ALL-UNNAMED`.
 
 Optional flags::
 [horizontal]
@@ -85,7 +85,7 @@ Recompilation is caused by any of these conditions:
 Recompilation causes the class path directory to be cleaned before the newly compiled classes are placed there.
 
 === Service file
-The file `META-INF/services/org.fedoraproject.javapackages.validator.spi.ValidatorFactory` is a standard https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ServiceLoader.html#deploying-service-providers-on-the-class-path-heading[Java service file].
+The file `META-INF/services/org.fedoraproject.javapackages.validator.spi.ValidatorFactory` is a standard https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/ServiceLoader.html#deploying-service-providers-on-the-class-path-heading[Java service file].
 It contains a line-separated list of validator factory class names which are available to be executed.
 This file will be copied from the source path to the class path and is expected to be present on the class path if source path is not specified.
 
@@ -119,7 +119,7 @@ The key is a tmt test name. The value of the field must be a list of strings. It
 
 `exclude-tests-matching`::
 The value of this field is a list of strings.
-The strings must be valid https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html[Java regular expressions].
+The strings must be valid https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/util/regex/Pattern.html[Java regular expressions].
 If any of these patterns matches the test name of a validator, it will be skipped.
 
 .Example of `javapackages-validator.yaml` configuration file

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     <dependency>
       <groupId>io.kojan</groupId>
       <artifactId>java-deptools-native</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.fedora-java</groupId>
@@ -88,10 +88,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>21</release>
-          <compilerArgs>
-            <arg>--enable-preview</arg>
-          </compilerArgs>
+          <release>22</release>
         </configuration>
       </plugin>
       <plugin>
@@ -102,6 +99,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           <archive>
             <manifest>
               <addClasspath>true</addClasspath>
+              <useUniqueVersions>false</useUniqueVersions>
               <classpathPrefix>dependency/</classpathPrefix>
               <mainClass>org.fedoraproject.javapackages.validator.Main</mainClass>
             </manifest>
@@ -130,7 +128,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.3.1</version>
         <configuration>
-          <argLine>--enable-preview --enable-native-access ALL-UNNAMED</argLine>
+          <argLine>--enable-native-access ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-java_bin='/usr/lib/jvm/jre-21-openjdk/bin'
+java_bin='/usr/lib/jvm/jre-22-openjdk/bin'
 
-exec "${java_bin}"/java --enable-preview --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
+exec "${java_bin}"/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
 
-# exec "${java_bin}"/java --enable-preview --enable-native-access ALL-UNNAMED -cp "target/classes$(find target/dependency -type f -printf ':%p')" org.fedoraproject.javapackages.validator.Main "${@}"
+# exec "${java_bin}"/java --enable-native-access ALL-UNNAMED -cp "target/classes$(find target/dependency -type f -printf ':%p')" org.fedoraproject.javapackages.validator.Main "${@}"

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -342,9 +342,8 @@ public class Main {
 
         if (parameters.outputDir != null) {
             var compilerArgs = new ArrayList<String>();
-            compilerArgs.add("--enable-preview");
             compilerArgs.add("--release");
-            compilerArgs.add("21");
+            compilerArgs.add("22");
             compilerArgs.add("-d");
             compilerArgs.add(parameters.outputDir.toString());
 

--- a/src/test/java/org/fedoraproject/javapackages/validator/validators/DuplicateFileValidatorTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/validators/DuplicateFileValidatorTest.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 
 import org.fedoraproject.javapackages.validator.TestCommon;
 import org.fedoraproject.javapackages.validator.util.DuplicateFileValidator.DefaultDuplicateFileValidator;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.kojan.javadeptools.rpm.RpmInfo;
@@ -53,7 +52,6 @@ public class DuplicateFileValidatorTest {
     }
 
     @Test
-    @Disabled("https://github.com/fedora-java/javapackages-validator/issues/86")
     void testDuplicateGhost() throws Exception {
         var validator = new DefaultDuplicateFileValidator() {
             @Override


### PR DESCRIPTION
Switch to Java 22:
- Use non-preview [FFM API](https://openjdk.org/jeps/454)

Switch to java-deptools-native 1.2.0:
- This release contains significant performance improvements.
- It supports files without content (#86).

Closes #104