### PR TITLE
In CI run validator just once

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,14 +1,15 @@
 FROM quay.io/fedora/fedora-minimal:rawhide AS builder
 RUN microdnf -y update
-RUN microdnf -y install findutils git-core koji make
+RUN microdnf -y install findutils koji make
 
 # Force rebuild
 RUN echo 4
 
-COPY "prepare_ci.sh" "/usr/local/src/"
-COPY "Makefile" "/usr/local/src/"
-RUN make -j12 -C "/usr/local/src"
+COPY prepare_ci.sh Makefile /src
+RUN mkdir /rpms
+WORKDIR /rpms
+RUN make -f /src/Makefile -j12 -Otarget
 
 FROM docker.io/library/alpine:3
-COPY --from=builder "/usr/local/src/rpms" "/usr/local/src/rpms"
-ENTRYPOINT ["cp", "-r", "/usr/local/src/rpms", "-t"]
+COPY --from=builder /rpms /rpms
+ENTRYPOINT ["cp", "-r", "/rpms", "-t"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-minimal:rawhide
+FROM quay.io/fedora/fedora-minimal:rawhide AS builder
 RUN microdnf -y update
 RUN microdnf -y install findutils git-core koji make
 
@@ -9,4 +9,6 @@ COPY "prepare_ci.sh" "/usr/local/src/"
 COPY "Makefile" "/usr/local/src/"
 RUN make -j12 -C "/usr/local/src"
 
+FROM docker.io/library/alpine:3
+COPY --from=builder "/usr/local/src/rpms" "/usr/local/src/rpms"
 ENTRYPOINT ["cp", "-r", "/usr/local/src/rpms", "-t"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += -r
-TARGET ?= rpms
+SRC_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-components:= $(addprefix $(TARGET)/,\
+components:= \
 ant \
 antlr \
 aopalliance \
@@ -144,13 +144,10 @@ xmlunit \
 xmvn \
 xmvn-generator \
 xz-java \
-)
 
 .PHONY: all
 
 all: $(components)
-$(TARGET):
-	@mkdir $@
-$(components): | $(TARGET)
+$(components): |
 	@echo $@
-	@cd $(@D) && "$${OLDPWD}/prepare_ci.sh" $(@F) || rm -rf $(@F)
+	@$(SRC_DIR)/prepare_ci.sh $(@F) || rm -rf $(@F)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ java_cup \
 javacc \
 javacc-maven-plugin \
 javapackages-bootstrap \
+javaparser \
 jaxb \
 jaxb-api \
 jaxb-dtd-parser \
@@ -123,7 +124,9 @@ plexus-languages \
 plexus-pom \
 plexus-resources \
 plexus-sec-dispatcher \
+plexus-testing \
 plexus-utils \
+plexus-xml \
 qdox \
 regexp \
 relaxng-datatype-java \
@@ -134,7 +137,6 @@ testng \
 univocity-parsers \
 velocity \
 xalan-j2 \
-xbean \
 xerces-j2 \
 xml-commons-apis \
 xml-commons-resolver \

--- a/prepare_ci.sh
+++ b/prepare_ci.sh
@@ -7,14 +7,5 @@ release="${2:-rawhide}"
 
 nevra="$(koji latest-pkg "${release}" "${component}" | tail -n +3)"
 nevra="${nevra%%[[:space:]]*}"
-echo "${nevra}"
-dist_git_url="$(koji buildinfo "${nevra}" | grep Extra | sed "s/.*git+\(.*\)'.*/\1/")"
-echo "${dist_git_url}"
-git clone "${dist_git_url%%#*}"
-cd "${component}"
-git checkout -q "${dist_git_url##*#}"
 
-mkdir rpms
-pushd rpms
-koji download-build --arch noarch --arch x86_64 --arch src --debuginfo "${nevra}"
-popd
+koji download-build --noprogress --arch noarch --arch x86_64 --arch src --debuginfo "${nevra}"


### PR DESCRIPTION
Run validator once on all packages.
This improves CI performance **a lot** (like from 11m 48s down to 1m 36s).
We can do that now as we don't have anything specific in component test plans any longer.
And we won't have as our nightly test runs (project Gacek) execute JPV tests in the same way -- all packages at once.

Also use two-stage build for CI image -- the resulting image is Alpine-based, which makes it a bit smaller.
Also update CI component list.