### PR TITLE
Logging improvements

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -171,6 +171,7 @@ public class Main {
         } catch (ArtifactResolutionException e) {
             throw new RuntimeException(e);
         }
+        logger.debug("Class path after dependency resolution: {0}", Decorated.plain(parameters.classPaths));
     }
 
     private void compileFiles() throws IOException {

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -213,6 +213,11 @@ public class Main {
 
         if (recompile) {
             FileUtils.cleanDirectory(outputDirectory.toFile());
+        }
+
+        resolveDependencies(props);
+
+        if (recompile) {
             var javac = ToolProvider.getSystemJavaCompiler();
             var fileManager = javac.getStandardFileManager(null, Locale.ROOT, StandardCharsets.UTF_8);
 
@@ -225,8 +230,6 @@ public class Main {
 
             compilerOptions.add("--release");
             compilerOptions.add(props.getProperty("compiler.release", "22"));
-
-            resolveDependencies(props);
 
             if (!parameters.classPaths.isEmpty()) {
                 compilerOptions.add("-cp");


### PR DESCRIPTION
Several improvements to logging for dependency resolution.

JPV logs now include entries like:

```
[DEBUG] Using remote repository central at https://repo.maven.apache.org/maven2
[DEBUG] Using remote repository repo0 at https://s01.oss.sonatype.org/content/repositories/snapshots
[DEBUG] Resolved dependency io.kojan:runit-api:jar:1.0.0-20240731.120908-1 from repository repo0
[DEBUG] Resolved dependency io.kojan:runit-validator:jar:1.0.0-20240731.120908-1 from repository repo0
[DEBUG] Resolved dependency org.apiguardian:apiguardian-api:jar:1.1.2 from repository central
[DEBUG] Resolved dependency org.hamcrest:hamcrest:jar:2.2 from repository central
[DEBUG] Resolved dependency org.junit.jupiter:junit-jupiter-api:jar:5.10.0 from repository central
[DEBUG] Resolved dependency org.junit.jupiter:junit-jupiter-engine:jar:5.10.0 from repository central
[DEBUG] Resolved dependency org.junit.platform:junit-platform-commons:jar:1.10.0 from repository central
[DEBUG] Resolved dependency org.junit.platform:junit-platform-engine:jar:1.10.0 from repository central
[DEBUG] Resolved dependency org.junit.platform:junit-platform-launcher:jar:1.10.0 from repository central
[DEBUG] Resolved dependency org.opentest4j:opentest4j:jar:1.3.0 from repository central
```