### PR TITLE
Build super JAR with maven-assembly-plugin

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -16,7 +16,6 @@ FROM docker.io/library/eclipse-temurin:22-jdk-ubi9-minimal
 RUN microdnf -y update
 RUN microdnf -y install rpm-libs
 
-COPY --from=builder "/usr/local/src/javapackages-validator/target/dependency/" "/opt/javapackages-validator/dependency/"
 COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"
 
 ENTRYPOINT ["/opt/java/openjdk/bin/java", "--enable-native-access", "ALL-UNNAMED", "-cp", "/opt/javapackages-validator/validator.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   </dependencies>
   
   <build>
-    <finalName>${project.name}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -106,30 +105,29 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.4.2</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <useUniqueVersions>false</useUniqueVersions>
-              <classpathPrefix>dependency/</classpathPrefix>
-              <mainClass>org.fedoraproject.javapackages.validator.Main</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
+        <artifactId>maven-assembly-plugin</artifactId>
         <version>3.7.1</version>
         <executions>
           <execution>
-            <id>copy-dependencies</id>
             <phase>package</phase>
             <goals>
-              <goal>copy-dependencies</goal>
+              <goal>single</goal>
             </goals>
             <configuration>
-              <includeScope>runtime</includeScope>
+              <finalName>${project.name}</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <attach>false</attach>
+              <archive>
+                <manifest>
+                  <mainClass>org.fedoraproject.javapackages.validator.Main</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -156,4 +156,30 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>dependency</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.7.1</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/run.sh
+++ b/run.sh
@@ -4,5 +4,3 @@ set -eu
 : ${JAVA_HOME:=/usr/lib/jvm/jre-22}
 
 exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
-
-# exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -cp "target/classes$(find target/dependency -type f -printf ':%p')" org.fedoraproject.javapackages.validator.Main "${@}"

--- a/run.sh
+++ b/run.sh
@@ -4,3 +4,5 @@ set -eu
 : ${JAVA_HOME:=/usr/lib/jvm/jre-22}
 
 exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
+
+# exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -cp "target/classes$(find target/dependency -type f -printf ':%p')" org.fedoraproject.javapackages.validator.Main "${@}"

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -371,10 +371,6 @@ public class Main {
 
         var validatorPath = Paths.get(MainTmt.class.getProtectionDomain().getCodeSource().getLocation().toURI());
         parameters.classPaths.add(validatorPath);
-        var parent = validatorPath.getParent();
-        if (parent != null) {
-            parameters.classPaths.add(parent.resolve("dependency").resolve("*"));
-        }
 
         logger = new Logger();
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -384,20 +384,16 @@ public class Main {
         logger.debug("Path arguments: {0}", Decorated.plain(parameters.argPaths));
         // logger.debug("URL arguments: {0}", Decorated.list(parameters.argUrls));
 
-        var expandedClassPaths = new ArrayList<Path>();
-        for (var classPath : parameters.classPaths) {
+        for (var it = parameters.classPaths.listIterator(); it.hasNext();) {
+            var classPath = it.next();
             var cpParent = classPath.getParent();
             if (classPath.endsWith("*") && cpParent != null && Files.isDirectory(cpParent)) {
                 try (var list = Files.list(cpParent).filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".jar"))) {
-                    list.forEach(expandedClassPaths::add);
+                    it.remove();
+                    list.forEach(it::add);
                 }
-            } else {
-                expandedClassPaths.add(classPath);
             }
         }
-        parameters.classPaths = expandedClassPaths;
-
-        logger.debug("Expanded class path: {0}", Decorated.plain(parameters.classPaths));
 
         return -1;
     }


### PR DESCRIPTION
Build super JAR with maven-assembly-plugin instead of thin JAR and `dependencies/` directory created wit help of maven-dependency-plugin

Fat JAR is built as `target/validator.jar`. It contains validator and all dependencies. Suitable for running with `java -jar`. Suitable for running from `tmt`.

Thin JAR without class-path is built as `target/validator-2.0.0-SNAPSHOT.jar`. Suitable for using as dependency once it will be deployed to Maven Central. Not suitable for `java -jar`.