### PR TITLE
Rebuild CI image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,7 @@ RUN microdnf -y update
 RUN microdnf -y install findutils koji make
 
 # Force rebuild
-RUN echo 4
+RUN echo 5
 
 COPY prepare_ci.sh Makefile /src
 RUN mkdir /rpms


### PR DESCRIPTION
Need to incorporate fix from https://bodhi.fedoraproject.org/updates/FEDORA-2024-fbc8bc3e71

Related: https://issues.redhat.com/browse/RHEL-53194