### PR TITLE
Switch to Solarized color palette

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -55,7 +55,7 @@ public class MainTmt extends Main {
         return result;
     }
 
-    private static final class HtmlTablePrintStream extends PrintStream {
+    static final class HtmlTablePrintStream extends PrintStream {
         public HtmlTablePrintStream(OutputStream os, TestResult result) throws IOException {
             super(os, false, StandardCharsets.UTF_8);
             var maxValue = switch (result)

--- a/src/main/resources/tmt_html/style.css
+++ b/src/main/resources/tmt_html/style.css
@@ -1,30 +1,50 @@
+/* Solarized color pallette.
+   See https://ethanschoonover.com/solarized/ */
+:root {
+  --base03:  #002b36;
+  --base02:  #073642;
+  --base01:  #586e75;
+  --base00:  #657b83;
+  --base0:   #839496;
+  --base1:   #93a1a1;
+  --base2:   #eee8d5;
+  --base3:   #fdf6e3;
+  --yellow:  #b58900;
+  --orange:  #cb4b16;
+  --red:     #dc322f;
+  --magenta: #d33682;
+  --violet:  #6c71c4;
+  --blue:    #268bd2;
+  --cyan:    #2aa198;
+  --green:   #859900;
+}
+
 table, th, td {
-  border: 1px solid black;
+  border: 1px solid var(--base02);
   border-collapse: collapse;
   font-family: monospace;
-  background-color: whitesmoke;
+  color: var(--base01);
+  background-color: var(--base3);
   padding: 4px;
+}
+th {
+  background-color: var(--base2);
 }
 td:first-child {
   text-align:center;
+  background-color: var(--base2);
 }
 
 /* for HtmlDecorator */
-.black          { color: black; }
-.red            { color: darkred; }
-.green          { color: darkgreen; }
-.yellow         { color: gold; }
-.blue           { color: darkblue; }
-.magenta        { color: darkmagenta; }
-.cyan           { color: darkcyan; }
-.white          { color: ghostwhite; }
-.bright.black   { color: darkgrey; }
-.bright.red     { color: red; }
-.bright.green   { color: green; }
-.bright.yellow  { color: goldenrod; }
-.bright.blue    { color: blue; }
-.bright.magenta { color: magenta; }
-.bright.cyan    { color: #00e5ff; }
-.bright.white   { color: white; }
+.black          { color: var(--base01); }
+.red            { color: var(--red); }
+.green          { color: var(--green); }
+.yellow         { color: var(--yellow); }
+.blue           { color: var(--blue); }
+.magenta        { color: var(--magenta); }
+.cyan           { color: var(--cyan); }
+.white          { color: var(--base0); }
+.bright.red     { color: var(--orange); }
+.bright.magenta { color: var(--violet); }
 .bold           { font-weight: bold; }
 .underline      { text-decoration: underline; }

--- a/src/test/java/org/fedoraproject/javapackages/validator/HtmlTablePrintStreamTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/HtmlTablePrintStreamTest.java
@@ -1,0 +1,82 @@
+package org.fedoraproject.javapackages.validator;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.fedoraproject.javapackages.validator.MainTmt.HtmlTablePrintStream;
+import org.fedoraproject.javapackages.validator.spi.Decorated;
+import org.fedoraproject.javapackages.validator.spi.Decoration;
+import org.fedoraproject.javapackages.validator.spi.Decoration.Color;
+import org.fedoraproject.javapackages.validator.spi.Decoration.Modifier;
+import org.fedoraproject.javapackages.validator.spi.LogEntry;
+import org.fedoraproject.javapackages.validator.spi.LogEvent;
+import org.fedoraproject.javapackages.validator.spi.TestResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class HtmlTablePrintStreamTest {
+
+    @TempDir
+    Path outDir;
+
+    @Test
+    void testHtmlGeneration() throws Exception {
+        var lorem =
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
+                        + "eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+        List<Optional<Color>> colors = new ArrayList<>();
+        colors.add(Optional.empty());
+        for (var color : Color.values()) {
+            colors.add(Optional.of(color));
+        }
+
+        List<Modifier[]> modas = new ArrayList<>();
+        for (int i = 0; i < 1 << Modifier.values().length; i++) {
+            List<Modifier> modifiers = new ArrayList<>();
+            for (int j = 0; j < Modifier.values().length; j++) {
+                if ((i & (1 << j)) != 0) {
+                    modifiers.add(Modifier.values()[j]);
+                }
+            }
+            var moda = modifiers.toArray(new Modifier[modifiers.size()]);
+            modas.add(moda);
+        }
+
+        List<LogEntry> entries = new ArrayList<>();
+        for (LogEvent event : LogEvent.values()) {
+            for (var moda : modas) {
+                for (var color : colors) {
+                    var entry =
+                            new LogEntry(
+                                    event,
+                                    "Text in color {0} and modifiers {1}: {2}",
+                                    Decorated.custom(color, new Decoration(color)),
+                                    Decorated.custom(Arrays.asList(moda), new Decoration(moda)),
+                                    Decorated.custom(lorem, new Decoration(color, moda)));
+                    entries.add(entry);
+                }
+            }
+        }
+
+        Path htmlDir = outDir.resolve("html");
+        Files.createDirectory(htmlDir);
+        for (String res : List.of("filter.js", "style.css")) {
+            try (var os = Files.newOutputStream(outDir.resolve(res));
+                    var is = MainTmt.class.getResourceAsStream("/tmt_html/" + res)) {
+                is.transferTo(os);
+            }
+        }
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            try (HtmlTablePrintStream htps = new HtmlTablePrintStream(bos, TestResult.info)) {
+                entries.forEach(htps::printRow);
+            }
+            Files.write(htmlDir.resolve("index.html"), bos.toByteArray());
+        }
+        System.err.println("Generated HTML is available at " + htmlDir);
+    }
+}


### PR DESCRIPTION
Currently it's hard to read Validator HTML reports due to poor selection of colors and in some cases low contrast (eg. yellow text on white background).
Instead of inventing a new color scheme, I propose to use [Solarized](https://ethanschoonover.com/solarized): a set of carefully selected colors designed for use in applications like Validator. Solarized improves readability and reduces eye fatigue.
I understand that this is a subjective matter (_de gustibus non est disputandum_), so feel free to ignore/close this PR.