### PR TITLE
Build and run with Java 23

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -1,4 +1,4 @@
-FROM docker.io/library/eclipse-temurin:22-jdk-ubi9-minimal AS builder
+FROM docker.io/library/eclipse-temurin:23-jdk-ubi9-minimal AS builder
 RUN microdnf -y install git-core maven rpm-libs
 
 WORKDIR "/usr/local/src/javapackages-validator"
@@ -12,7 +12,7 @@ RUN mvn -B -U clean install javadoc:javadoc
 
 ################################################################################
 
-FROM docker.io/library/eclipse-temurin:22-jdk-ubi9-minimal
+FROM docker.io/library/eclipse-temurin:23-jdk-ubi9-minimal
 RUN microdnf -y update
 RUN microdnf -y install rpm-libs
 

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-: ${JAVA_HOME:=/usr/lib/jvm/jre-22}
+: ${JAVA_HOME:=/usr/lib/jvm/jre-23}
 
 exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
 


### PR DESCRIPTION
Java 22 is still the minimal target, but Dockerfiles will use Java 23.