### PR TITLE
run.sh: Use JAVA_HOME from Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,24 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+        <executions>
+          <execution>
+            <id>build-classpath</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>build-classpath</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+              <outputFile>${project.build.directory}/classpath</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
   </dependencies>
   
   <build>
+    <resources>
+      <resource>
+        <filtering>false</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources-filtered</directory>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -105,6 +115,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.4.2</version>
+        <configuration>
+          <excludes>
+            <exclude>**/JAVA_HOME</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
-: ${JAVA_HOME:=/usr/lib/jvm/jre-23}
+if [ -z "${JAVA_HOME:-}" ]; then
+    JAVA_HOME=$(cat target/classes/JAVA_HOME)
+fi
 
 exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
 

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,4 @@ if [ -z "${JAVA_HOME:-}" ]; then
     JAVA_HOME=$(cat target/classes/JAVA_HOME)
 fi
 
-exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -jar 'target/validator.jar' "${@}"
-
-# exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -cp "target/classes$(find target/dependency -type f -printf ':%p')" org.fedoraproject.javapackages.validator.Main "${@}"
+exec "${JAVA_HOME}"/bin/java --enable-native-access ALL-UNNAMED -cp "target/classes:$(cat target/classpath)" org.fedoraproject.javapackages.validator.Main "${@}"

--- a/src/main/resources-filtered/JAVA_HOME
+++ b/src/main/resources-filtered/JAVA_HOME
@@ -1,0 +1,1 @@
+${java.home}


### PR DESCRIPTION
For run.sh script use the same Java as for running unit tests, but let the user override by setting JAVA_HOME explicitly.

Related: #166