### PR TITLE
Use jlink to minimize runtime container size

### DIFF
--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -1,5 +1,6 @@
 FROM docker.io/library/eclipse-temurin:23-jdk-ubi9-minimal AS builder
 RUN microdnf -y install git-core maven rpm-libs
+RUN mkdir /opt/rpm-libs && cp /usr/lib64/librpm.so.9 $(ldd /usr/lib64/librpm.so.9 | awk '{print$3}') /opt/rpm-libs
 
 WORKDIR "/usr/local/src/javapackages-validator"
 
@@ -15,10 +16,9 @@ RUN jlink --output "/opt/jre" --strip-debug --no-man-pages --no-header-files \
 
 ################################################################################
 
-FROM registry.access.redhat.com/ubi9-minimal:latest
-RUN microdnf -y update
-RUN microdnf -y install rpm-libs
+FROM registry.access.redhat.com/ubi9-micro:latest
 
+COPY --from=builder "/opt/rpm-libs/*" "/usr/lib64"
 COPY --from=builder "/opt/jre" "/opt/java/openjdk"
 COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"
 

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -10,12 +10,16 @@ RUN mvn -B clean install javadoc:javadoc
 COPY "src/" "/usr/local/src/javapackages-validator/src/"
 RUN mvn -B -U clean install javadoc:javadoc
 
+RUN jlink --output "/opt/jre" --strip-debug --no-man-pages --no-header-files \
+ --add-modules java.base,java.compiler,java.xml,java.naming,javax.tools
+
 ################################################################################
 
-FROM docker.io/library/eclipse-temurin:23-jdk-ubi9-minimal
+FROM registry.access.redhat.com/ubi9-minimal:latest
 RUN microdnf -y update
 RUN microdnf -y install rpm-libs
 
+COPY --from=builder "/opt/jre" "/opt/java/openjdk"
 COPY --from=builder "/usr/local/src/javapackages-validator/target/validator.jar" "/opt/javapackages-validator/validator.jar"
 
 ENTRYPOINT ["/opt/java/openjdk/bin/java", "--enable-native-access", "ALL-UNNAMED", "-cp", "/opt/javapackages-validator/validator.jar"]

--- a/Dockerfile.main
+++ b/Dockerfile.main
@@ -11,7 +11,7 @@ COPY "src/" "/usr/local/src/javapackages-validator/src/"
 RUN mvn -B -U clean install javadoc:javadoc
 
 RUN jlink --output "/opt/jre" --strip-debug --no-man-pages --no-header-files \
- --add-modules java.base,java.compiler,java.xml,java.naming,javax.tools
+ --add-modules java.base,jdk.compiler,java.xml,java.naming
 
 ################################################################################
 


### PR DESCRIPTION
An attempt to minimize the JVM size to only the needed parts.
My size listing shows:
```
$ podman images javapackages-validator --format "{{.Repository}}:{{.Tag}} -> {{.Size}}"
quay.io/fedora-java/javapackages-validator:latest -> 550 MB
$ podman images jpv --format "{{.Repository}}:{{.Tag}} -> {{.Size}}"
localhost/jpv:latest -> 199 MB
```
Assuming JPV works correctly, this looks like a very good improvement.