### PR TITLE
Warn when BytecodeVersionValidator is ran without limits

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
@@ -9,6 +9,14 @@ import org.fedoraproject.javapackages.validator.util.BytecodeVersionJarValidator
 
 import io.kojan.javadeptools.rpm.RpmPackage;
 
+/**
+ * BytecodeVersionValidator can be ran in two modes &ndash; enforcing and
+ * informative. When configured with max and min bytecode versions (the limits)
+ * then it enforces class bytecode versions, producing failures for cases where
+ * the actual version does not fit within the configured range. Otherwise, when
+ * ran without limits specified, its results are only informative &ndash; it
+ * only prints bytecode versions found as infos.
+ */
 public class BytecodeVersionValidator extends BytecodeVersionJarValidator {
     @Override
     public String getTestName() {

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
@@ -65,6 +65,7 @@ public class BytecodeVersionValidator extends BytecodeVersionJarValidator {
     public void validate(RpmPackage rpm, Path jarPath, Map<Path, Version> classVersions) {
         var limits = readLimits();
         if (limits == null) {
+            warn("No limits were configured for " + getTestName() + ", the results will only be informative.");
             super.validate(rpm, jarPath, classVersions);
             return;
         }

--- a/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
@@ -53,4 +53,8 @@ public class TestCommon {
         }
         assertEquals(1, count);
     }
+
+    public static void assertError(Result result) {
+        assertEquals(TestResult.error, result.getResult(), "expected result: ERROR");
+    }
 }

--- a/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/TestCommon.java
@@ -43,6 +43,10 @@ public class TestCommon {
         assertEquals(TestResult.info, result.getResult(), "expected result: INFO");
     }
 
+    public static void assertWarn(Result result) {
+        assertEquals(TestResult.warn, result.getResult(), "expected result: WARN");
+    }
+
     public static void assertFailOne(Result result) {
         assertEquals(TestResult.fail, result.getResult(), "expected result: FAIL");
         int count = 0;

--- a/src/test/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidatorTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidatorTest.java
@@ -1,0 +1,90 @@
+package org.fedoraproject.javapackages.validator.validators;
+
+import static org.fedoraproject.javapackages.validator.TestCommon.assertError;
+import static org.fedoraproject.javapackages.validator.TestCommon.assertFailOne;
+import static org.fedoraproject.javapackages.validator.TestCommon.assertInfo;
+import static org.fedoraproject.javapackages.validator.TestCommon.assertPass;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.fedoraproject.javapackages.validator.TestCommon;
+import org.fedoraproject.javapackages.validator.spi.Decorated;
+import org.fedoraproject.javapackages.validator.spi.LogEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kojan.javadeptools.rpm.RpmPackage;
+
+public class BytecodeVersionValidatorTest {
+    static final Iterable<RpmPackage> RPMS = TestCommon.fromPaths(
+            TestCommon.RPM_PATH_PREFIX.resolve(Path.of("noarch/jpms-automatic-1-1.noarch.rpm")),
+            TestCommon.RPM_PATH_PREFIX.resolve(Path.of("noarch/jpms-invalid-1-1.noarch.rpm")));
+
+    List<String> msgs;
+    BytecodeVersionValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        msgs = new ArrayList<>();
+        validator = new BytecodeVersionValidator() {
+            public void addLog(LogEntry ent) {
+                String msg = MessageFormat.format(ent.pattern(),
+                        Stream.of(ent.objects()).map(Decorated::getObject).toArray());
+                msgs.add(msg);
+                System.out.println("[" + ent.kind().getDecorated().getObject() + "] " + msg);
+                super.addLog(ent);
+            }
+        };
+    }
+
+    void assertMsg(String exp) {
+        for (String msg : msgs) {
+            if (msg.contains(exp)) {
+                return;
+            }
+        }
+        fail("Expected message: " + exp);
+    }
+
+    @Test
+    void testInfo() throws Exception {
+        validator.validate(RPMS, null);
+        assertInfo(validator.build());
+        assertMsg("module-info.class: bytecode version: 65.0");
+    }
+
+    @Test
+    void testPass() throws Exception {
+        validator.validate(RPMS, List.of("12:345"));
+        assertPass(validator.build());
+        assertMsg("Limits: 12:345");
+        assertMsg("found bytecode versions: [65.0]");
+    }
+
+    @Test
+    void testFail() throws Exception {
+        validator.validate(RPMS, List.of("42"));
+        assertFailOne(validator.build());
+        assertMsg("Limits: 42:42");
+        assertMsg("bytecode version: 65.0 is larger than 42");
+    }
+
+    @Test
+    void testEmptyArgs() throws Exception {
+        validator.validate(RPMS, List.of());
+        assertError(validator.build());
+        assertMsg("Wrong number of arguments, expected 1");
+    }
+
+    @Test
+    void testTooManyArgs() throws Exception {
+        validator.validate(RPMS, List.of("12", "34"));
+        assertError(validator.build());
+        assertMsg("Wrong number of arguments, expected 1");
+    }
+}

--- a/src/test/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidatorTest.java
+++ b/src/test/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidatorTest.java
@@ -2,8 +2,8 @@ package org.fedoraproject.javapackages.validator.validators;
 
 import static org.fedoraproject.javapackages.validator.TestCommon.assertError;
 import static org.fedoraproject.javapackages.validator.TestCommon.assertFailOne;
-import static org.fedoraproject.javapackages.validator.TestCommon.assertInfo;
 import static org.fedoraproject.javapackages.validator.TestCommon.assertPass;
+import static org.fedoraproject.javapackages.validator.TestCommon.assertWarn;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Path;
@@ -52,10 +52,11 @@ public class BytecodeVersionValidatorTest {
     }
 
     @Test
-    void testInfo() throws Exception {
+    void testInformative() throws Exception {
         validator.validate(RPMS, null);
-        assertInfo(validator.build());
+        assertWarn(validator.build());
         assertMsg("module-info.class: bytecode version: 65.0");
+        assertMsg("No limits were configured for /java/bytecode-version, the results will only be informative");
     }
 
     @Test


### PR DESCRIPTION
BytecodeVersionValidator should not be ran in informative mode in
automated tests, where alternative BytecodeVersionJarValidatorJP
should be used instead.  Therefore add a warning issued when
BytecodeVersionValidator is ran in informative mode, which is treated
by test automation as failure.

Depends on #174