### PR TITLE
Silence deprecation warning in Maven Resolver

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,6 +43,7 @@ import org.apache.commons.compress.utils.Iterators;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.aether.AbstractRepositoryListener;
 import org.eclipse.aether.RepositoryEvent;
+import org.eclipse.aether.RepositorySystemSession.SessionBuilder;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
@@ -167,7 +169,8 @@ public class Main {
                 .map(repo -> new RemoteRepository.Builder(repo.getKey(), "default", repo.getValue()).build())
                 .collect(Collectors.toList());
         var aether = new RepositorySystemSupplier().get();
-        try (var session = new SessionBuilderSupplier(aether).get()
+        Supplier<SessionBuilder> sbs = new SessionBuilderSupplier(aether);
+        try (var session = sbs.get()
                 .withLocalRepositoryBaseDirectories(parameters.outputDir.resolve("local-repo"))
                 .withRepositoryListener(new AbstractRepositoryListener() {
                     public void artifactResolved(RepositoryEvent event) {


### PR DESCRIPTION
Class `SessionBuilderSupplier` (from Maven Resolver)
extends `MavenSessionBuilderSupplier` (from Maven), which
implements `Supplier<SessionBuilder>` (from Java base).

Method `get()` was deprecated in `MavenSessionBuilderSupplier`,
and deprecation is inherited by `SessionBuilderSupplier`, although it shouldn't be.
To work this around we cast the instance of `SessionBuilderSupplier` to `Supplier<SessionBuilder>`
and invoke its `get()` method, which is not deprecated.