### PR TITLE
Make generated HTML self-contained

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/MainTmt.java
@@ -21,6 +21,7 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.IterableUtils;
+import org.apache.commons.io.IOUtils;
 import org.fedoraproject.javapackages.validator.spi.Decorated;
 import org.fedoraproject.javapackages.validator.spi.LogEntry;
 import org.fedoraproject.javapackages.validator.spi.LogEvent;
@@ -68,13 +69,24 @@ public class MainTmt extends Main {
             case error -> LogEvent.error;
             };
 
+            String filterJs = IOUtils.toString(MainTmt.class.getResource("/tmt_html/filter.js"), StandardCharsets.UTF_8);
+            String styleCss = IOUtils.toString(MainTmt.class.getResource("/tmt_html/style.css"), StandardCharsets.UTF_8);
+
             var ps = new PrintStream(super.out, false, StandardCharsets.UTF_8);
             ps.append("""
 <!DOCTYPE html>
 <html>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
-<script src="../filter.js"></script>
-<link rel="stylesheet" href="../style.css">
+<script type="text/javascript">
+""");
+            ps.append(filterJs);
+            ps.append("""
+</script>
+<style type="text/css">
+""");
+            ps.append(styleCss);
+            ps.append("""
+</style>
 <table>
 <tr>
     <th>Filter:</th>
@@ -207,15 +219,6 @@ public class MainTmt extends Main {
 
     @Override
     protected int report(List<NamedResult> results) throws Exception {
-        try (var os = Files.newOutputStream(TMT_TEST_DATA.resolve("filter.js"));
-                var is = MainTmt.class.getResourceAsStream("/tmt_html/filter.js")) {
-            is.transferTo(os);
-        }
-        try (var os = Files.newOutputStream(TMT_TEST_DATA.resolve("style.css"));
-                var is = MainTmt.class.getResourceAsStream("/tmt_html/style.css")) {
-            is.transferTo(os);
-        }
-
         Files.createDirectories(TMT_TEST_DATA.resolve("results"));
 
         var testResults = IterableUtils.chainedIterable(results, this.reports.entrySet().stream()


### PR DESCRIPTION
Embed resources  `filter.js` and `style.css` directly in generated HTML files to make them self-contained to ease sharing.

The external resources make it hard to share generated HTML with others.
In contrast, with standalone HTML it's super-easy to attach the HTML file and upload it somewhere, or send it over email, instant messaging etc.

The resource files are small-enough to justify embedding them.

JQuery remains an external resource, but it is available from anywhere, so it doesn't need to be embedded.