### PR TITLE
Disable annotation processing when compiling sources

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -243,6 +243,8 @@ public class Main {
 
             logger.debug("Compiling source files: {0}", Decorated.plain(sourceFiles));
 
+            compilerOptions.add("-proc:none");
+
             compilerOptions.add("--release");
             compilerOptions.add(props.getProperty("compiler.release", "22"));
 


### PR DESCRIPTION
When compiling sources, the following note is printed:
```
Note: Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```