### PR TITLE
ForkJoinPool and fine-grained parallel validators

### DIFF
--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -85,6 +85,7 @@ public class Main {
         static final Flag CLASS_PATH = new Flag("-cp", "--class-path");
 
         static final Flag FILE = new Flag("-f", "--file");
+        static final Flag FILES = new Flag("--files");
         // static final Flag URL = new Flag("-u", "--url");
 
         static final Flag HELP = new Flag("-h", "--help");
@@ -101,7 +102,7 @@ public class Main {
         }
 
         static final Flag[] ALL_FLAGS = new Flag[] {
-            SOURCE_PATH, OUTPUT_DIRECTORY, CLASS_PATH, FILE, /*URL,*/ HELP, COLOR, DEBUG,
+            SOURCE_PATH, OUTPUT_DIRECTORY, CLASS_PATH, FILE, FILES, HELP, COLOR, DEBUG,
         };
     }
 
@@ -332,7 +333,7 @@ public class Main {
         }
 
         Flag lastFlag = null;
-        for (int i = 0; i != args.length; ++i) {
+        for (int i = 0; i < args.length; ++i) {
             if (args[i].startsWith("-")) {
                 lastFlag = null;
 
@@ -371,6 +372,11 @@ public class Main {
                 parameters.classPaths.add(resolveRelativePathCommon(args[i]));
             } else if (lastFlag == Flag.FILE) {
                 parameters.argPaths.add(Path.of(args[i]));
+            } else if (lastFlag == Flag.FILES) {
+                while (i != args.length) {
+                    parameters.argPaths.add(Path.of(args[i]));
+                    ++i;
+                }
             }
         }
 

--- a/src/main/java/org/fedoraproject/javapackages/validator/Main.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/Main.java
@@ -173,6 +173,7 @@ public class Main {
         try (var session = sbs.get()
                 .withLocalRepositoryBaseDirectories(parameters.outputDir.resolve("local-repo"))
                 .withRepositoryListener(new AbstractRepositoryListener() {
+                    @Override
                     public void artifactResolved(RepositoryEvent event) {
                         logger.debug("Resolved dependency {0} from repository {1}",
                                 Decorated.actual(event.getArtifact()), Decorated.struct(event.getRepository().getId()));

--- a/src/main/java/org/fedoraproject/javapackages/validator/ThreadPool.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/ThreadPool.java
@@ -1,0 +1,26 @@
+package org.fedoraproject.javapackages.validator;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Future;
+
+public final class ThreadPool {
+    private static final class Lazy {
+        private static final ForkJoinPool INSTANCE = new ForkJoinPool();
+    }
+
+    private ThreadPool() {
+    }
+
+    public static synchronized Future<?> submit(Runnable task) {
+        return Lazy.INSTANCE.submit(task);
+    }
+
+    public static synchronized <T> Future<T> submit(Callable<T> task) {
+        return Lazy.INSTANCE.submit(task);
+    }
+
+    public static synchronized int getParallelism() {
+        return Lazy.INSTANCE.getParallelism();
+    }
+}

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/BytecodeVersionJarValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/BytecodeVersionJarValidator.java
@@ -22,6 +22,11 @@ public abstract class BytecodeVersionJarValidator extends JarValidator {
         }
     }
 
+    @Override
+    protected RpmJarResultBuilder spawnValidator() {
+        return new BytecodeVersionJarResultBuilder();
+    }
+
     public static class BytecodeVersionJarResultBuilder extends RpmJarResultBuilder {
         @Override
         public void acceptJarEntry(RpmPackage rpm, CpioArchiveEntry rpmEntry, byte[] content) throws Exception {

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/BytecodeVersionJarValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/BytecodeVersionJarValidator.java
@@ -22,42 +22,44 @@ public abstract class BytecodeVersionJarValidator extends JarValidator {
         }
     }
 
-    @Override
-    public void acceptJarEntry(RpmPackage rpm, CpioArchiveEntry rpmEntry, byte[] content) throws Exception {
-        var jarPath = Path.of(rpmEntry.getName().substring(1));
-        var classVersions = new TreeMap<Path, Version>();
+    public static class BytecodeVersionJarResultBuilder extends RpmJarResultBuilder {
+        @Override
+        public void acceptJarEntry(RpmPackage rpm, CpioArchiveEntry rpmEntry, byte[] content) throws Exception {
+            var jarPath = Path.of(rpmEntry.getName().substring(1));
+            var classVersions = new TreeMap<Path, Version>();
 
-        try (var jarStream = new JarInputStream(new ByteArrayInputStream(content))) {
-            for (JarEntry jarEntry; (jarEntry = jarStream.getNextJarEntry()) != null;) {
-                var classPath = Path.of(jarEntry.getName());
+            try (var jarStream = new JarInputStream(new ByteArrayInputStream(content))) {
+                for (JarEntry jarEntry; (jarEntry = jarStream.getNextJarEntry()) != null;) {
+                    var classPath = Path.of(jarEntry.getName());
 
-                if (classPath.toString().endsWith(".class")) {
-                    var dataInput = new DataInputStream(jarStream);
-                    dataInput.readInt(); // magic number
-                    var minorVersion = dataInput.readShort();
-                    var majorVersion = dataInput.readShort();
-                    classVersions.put(classPath, new Version(majorVersion, minorVersion));
+                    if (classPath.toString().endsWith(".class")) {
+                        var dataInput = new DataInputStream(jarStream);
+                        dataInput.readInt(); // magic number
+                        var minorVersion = dataInput.readShort();
+                        var majorVersion = dataInput.readShort();
+                        classVersions.put(classPath, new Version(majorVersion, minorVersion));
+                    }
                 }
+            }
+
+            validate(rpm, jarPath, classVersions);
+
+            if (TestResult.pass.equals(getResult())) {
+                pass("{0}: {1}: found bytecode versions: {2}",
+                        Decorated.rpm(rpm),
+                        Decorated.custom(jarPath, DECORATION_JAR),
+                        Decorated.actual(classVersions.values().stream().distinct().toList()));
             }
         }
 
-        validate(rpm, jarPath, classVersions);
-
-        if (TestResult.pass.equals(getResult())) {
-            pass("{0}: {1}: found bytecode versions: {2}",
-                    Decorated.rpm(rpm),
-                    Decorated.custom(jarPath, DECORATION_JAR),
-                    Decorated.actual(classVersions.values().stream().distinct().toList()));
-        }
-    }
-
-    public void validate(RpmPackage rpm, Path jarPath, Map<Path, Version> classVersions) {
-        for (var entry : classVersions.entrySet()) {
-            info("{0}: {1}: {2}: bytecode version: {3}",
-                    Decorated.rpm(rpm),
-                    Decorated.custom(jarPath, DECORATION_JAR),
-                    Decorated.struct(entry.getKey()),
-                    Decorated.actual(entry.getValue()));
+        public void validate(RpmPackage rpm, Path jarPath, Map<Path, Version> classVersions) {
+            for (var entry : classVersions.entrySet()) {
+                info("{0}: {1}: {2}: bytecode version: {3}",
+                        Decorated.rpm(rpm),
+                        Decorated.custom(jarPath, DECORATION_JAR),
+                        Decorated.struct(entry.getKey()),
+                        Decorated.actual(entry.getValue()));
+            }
         }
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/ConcurrentValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/ConcurrentValidator.java
@@ -1,0 +1,53 @@
+package org.fedoraproject.javapackages.validator.util;
+
+import java.util.ArrayList;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
+
+import org.fedoraproject.javapackages.validator.ThreadPool;
+
+import io.kojan.javadeptools.rpm.RpmInfo;
+import io.kojan.javadeptools.rpm.RpmPackage;
+
+public abstract class ConcurrentValidator extends ElementwiseValidator {
+    protected ConcurrentValidator() {
+        this(_ -> true);
+    }
+
+    protected ConcurrentValidator(Predicate<RpmInfo> filter) {
+        super(filter);
+    }
+
+    public final void validate(RpmPackage rpm) throws Exception {
+    }
+
+    @Override
+    public void validate(Iterable<RpmPackage> rpms) throws Exception {
+        var futures = new ArrayList<Future<ElementwiseResultBuilder>>();
+        var it = filter(rpms);
+        while (it.hasNext()) {
+            var rpm = it.next();
+            var resultBuilder = spawnValidator();
+            futures.add(ThreadPool.submit(() -> {
+                try {
+                    resultBuilder.validate(rpm);
+                } catch (Exception ex) {
+                    resultBuilder.error(ex);
+                }
+                return resultBuilder;
+            }));
+        }
+        for (var future : futures) {
+            mergeResult(future.get());
+        }
+    }
+
+    protected void mergeResult(ElementwiseResultBuilder resultBuilder) {
+        mergeResult(resultBuilder.getResult());
+        for (var entry : resultBuilder.getLog()) {
+            addLog(entry);
+        }
+    }
+
+    protected abstract ElementwiseResultBuilder spawnValidator();
+}

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/ElementwiseResultBuilder.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/ElementwiseResultBuilder.java
@@ -1,0 +1,9 @@
+package org.fedoraproject.javapackages.validator.util;
+
+import org.fedoraproject.javapackages.validator.spi.ResultBuilder;
+
+import io.kojan.javadeptools.rpm.RpmPackage;
+
+public abstract class ElementwiseResultBuilder extends ResultBuilder {
+    public abstract void validate(RpmPackage rpm) throws Exception;
+}

--- a/src/main/java/org/fedoraproject/javapackages/validator/util/JarValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/util/JarValidator.java
@@ -3,11 +3,12 @@ package org.fedoraproject.javapackages.validator.util;
 import java.util.function.Predicate;
 
 import org.fedoraproject.javapackages.validator.spi.Decoration;
+import org.fedoraproject.javapackages.validator.util.JarValidator.RpmJarResultBuilder;
 
 import io.kojan.javadeptools.rpm.RpmInfo;
 import io.kojan.javadeptools.rpm.RpmPackage;
 
-public abstract class JarValidator extends ElementwiseValidator implements RpmJarConsumer {
+public abstract class JarValidator extends ConcurrentValidator {
     public static final Decoration DECORATION_JAR = new Decoration(Decoration.Color.blue, Decoration.Modifier.bright);
 
     protected JarValidator() {
@@ -18,8 +19,13 @@ public abstract class JarValidator extends ElementwiseValidator implements RpmJa
         super(filter);
     }
 
-    @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        accept(rpm);
+    protected static abstract class RpmJarResultBuilder extends ElementwiseResultBuilder implements RpmJarConsumer {
+        @Override
+        public void validate(RpmPackage rpm) throws Exception {
+            accept(rpm);
+        }
     }
+
+    @Override
+    protected abstract RpmJarResultBuilder spawnValidator();
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/AttributeBuildRequiresValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/AttributeBuildRequiresValidator.java
@@ -1,11 +1,12 @@
 package org.fedoraproject.javapackages.validator.validators;
 
-import org.fedoraproject.javapackages.validator.util.ElementwiseValidator;
+import org.fedoraproject.javapackages.validator.util.ConcurrentValidator;
+import org.fedoraproject.javapackages.validator.util.ElementwiseResultBuilder;
 
 import io.kojan.javadeptools.rpm.RpmInfo;
 import io.kojan.javadeptools.rpm.RpmPackage;
 
-public class AttributeBuildRequiresValidator extends ElementwiseValidator {
+public class AttributeBuildRequiresValidator extends ConcurrentValidator {
     @Override
     public String getTestName() {
         return "/java/attributes/build-requires";
@@ -16,7 +17,12 @@ public class AttributeBuildRequiresValidator extends ElementwiseValidator {
     }
 
     @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        // TODO
+    protected ElementwiseResultBuilder spawnValidator() {
+        return new ElementwiseResultBuilder() {
+            @Override
+            public void validate(RpmPackage rpm) throws Exception {
+                // TODO
+            }
+        };
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/AttributeRequiresValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/AttributeRequiresValidator.java
@@ -1,16 +1,18 @@
 package org.fedoraproject.javapackages.validator.validators;
 
+
 import java.util.function.Predicate;
 
 import org.fedoraproject.javapackages.validator.spi.Decorated;
 import org.fedoraproject.javapackages.validator.spi.TestResult;
-import org.fedoraproject.javapackages.validator.util.ElementwiseValidator;
+import org.fedoraproject.javapackages.validator.util.ConcurrentValidator;
+import org.fedoraproject.javapackages.validator.util.ElementwiseResultBuilder;
 
 import io.kojan.javadeptools.rpm.RpmDependency;
 import io.kojan.javadeptools.rpm.RpmInfo;
 import io.kojan.javadeptools.rpm.RpmPackage;
 
-public class AttributeRequiresValidator extends ElementwiseValidator {
+public class AttributeRequiresValidator extends ConcurrentValidator {
     @Override
     public String getTestName() {
         return "/java/attributes/requires";
@@ -21,25 +23,30 @@ public class AttributeRequiresValidator extends ElementwiseValidator {
     }
 
     @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        boolean jpFilesystem = false;
+    protected ElementwiseResultBuilder spawnValidator() {
+        return new ElementwiseResultBuilder() {
+            @Override
+            public void validate(RpmPackage rpm) throws Exception {
+                boolean jpFilesystem = false;
 
-        for (RpmDependency require : rpm.getInfo().getRequires()) {
-            jpFilesystem |= require.getName().equals("javapackages-filesystem");
-            if (require.getName().startsWith("mvn(") && require.getName().endsWith(")")) {
-                if (require.getVersion().getVersion().chars().noneMatch(Character::isDigit)) {
-                    fail("{0}: The required version of field {1} does not contain a number",
-                            Decorated.rpm(rpm), Decorated.actual(require));
+                for (RpmDependency require : rpm.getInfo().getRequires()) {
+                    jpFilesystem |= require.getName().equals("javapackages-filesystem");
+                    if (require.getName().startsWith("mvn(") && require.getName().endsWith(")")) {
+                        if (require.getVersion().getVersion().chars().noneMatch(Character::isDigit)) {
+                            fail("{0}: The required version of field {1} does not contain a number",
+                                    Decorated.rpm(rpm), Decorated.actual(require));
+                        }
+                    }
+                }
+
+                if (!jpFilesystem) {
+                    // fail("{0}: Requires field does not contain javapackages-filesystem", Decorated.rpm(rpm));
+                }
+
+                if (!TestResult.fail.equals(getResult())) {
+                    pass("{0}: RPM attribute Requires ok", Decorated.rpm(rpm));
                 }
             }
-        }
-
-        if (!jpFilesystem) {
-            // fail("{0}: Requires field does not contain javapackages-filesystem", Decorated.rpm(rpm));
-        }
-
-        if (!TestResult.fail.equals(getResult())) {
-            pass("{0}: RPM attribute Requires ok", Decorated.rpm(rpm));
-        }
+        };
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/BytecodeVersionValidator.java
@@ -10,6 +10,8 @@ import org.fedoraproject.javapackages.validator.util.BytecodeVersionJarValidator
 import io.kojan.javadeptools.rpm.RpmPackage;
 
 public class BytecodeVersionValidator extends BytecodeVersionJarValidator {
+    private Limits limits = null;
+
     @Override
     public String getTestName() {
         return "/java/bytecode-version";
@@ -54,45 +56,55 @@ public class BytecodeVersionValidator extends BytecodeVersionJarValidator {
     }
 
     @Override
-    public void validate(RpmPackage rpm, Path jarPath, Map<Path, Version> classVersions) {
-        var limits = readLimits();
-        if (limits == null) {
-            super.validate(rpm, jarPath, classVersions);
-            return;
-        }
+    public void validate(Iterable<RpmPackage> rpms) throws Exception {
+        this.limits = readLimits();
+        super.validate(rpms);
+    }
 
-        debug("Limits: {0}:{1}", Decorated.plain(limits.min()), Decorated.plain(limits.max()));
-        for (var entry : classVersions.entrySet()) {
-            boolean failed = false;
+    @Override
+    protected RpmJarResultBuilder spawnValidator() {
+        return new BytecodeVersionJarResultBuilder() {
+            @Override
+            public void validate(RpmPackage rpm, Path jarPath, Map<Path, Version> classVersions) {
+                if (limits == null) {
+                    super.validate(rpm, jarPath, classVersions);
+                    return;
+                }
 
-            if (entry.getValue().major() < limits.min()) {
-                failed = true;
-                fail("{0}: {1}: {2}: bytecode version: {3} is smaller than {4}",
-                        Decorated.rpm(rpm),
-                        Decorated.custom(jarPath, DECORATION_JAR),
-                        Decorated.struct(entry.getKey()),
-                        Decorated.actual(entry.getValue()),
-                        Decorated.expected(limits.min()));
+                debug("Limits: {0}:{1}", Decorated.plain(limits.min()), Decorated.plain(limits.max()));
+                for (var entry : classVersions.entrySet()) {
+                    boolean failed = false;
+
+                    if (entry.getValue().major() < limits.min()) {
+                        failed = true;
+                        fail("{0}: {1}: {2}: bytecode version: {3} is smaller than {4}",
+                                Decorated.rpm(rpm),
+                                Decorated.custom(jarPath, DECORATION_JAR),
+                                Decorated.struct(entry.getKey()),
+                                Decorated.actual(entry.getValue()),
+                                Decorated.expected(limits.min()));
+                    }
+
+                    if (limits.max() < entry.getValue().major()) {
+                        failed = true;
+                        fail("{0}: {1}: {2}: bytecode version: {3} is larger than {4}",
+                                Decorated.rpm(rpm),
+                                Decorated.custom(jarPath, DECORATION_JAR),
+                                Decorated.struct(entry.getKey()),
+                                Decorated.actual(entry.getValue()),
+                                Decorated.expected(limits.max()));
+                    }
+
+                    if (!failed) {
+                        mergeResult(TestResult.pass);
+                        debug("{0}: {1}: {2}: bytecode version: {3}",
+                                Decorated.rpm(rpm),
+                                Decorated.custom(jarPath, DECORATION_JAR),
+                                Decorated.struct(entry.getKey()),
+                                Decorated.actual(entry.getValue()));
+                    }
+                }
             }
-
-            if (limits.max() < entry.getValue().major()) {
-                failed = true;
-                fail("{0}: {1}: {2}: bytecode version: {3} is larger than {4}",
-                        Decorated.rpm(rpm),
-                        Decorated.custom(jarPath, DECORATION_JAR),
-                        Decorated.struct(entry.getKey()),
-                        Decorated.actual(entry.getValue()),
-                        Decorated.expected(limits.max()));
-            }
-
-            if (!failed) {
-                mergeResult(TestResult.pass);
-                debug("{0}: {1}: {2}: bytecode version: {3}",
-                        Decorated.rpm(rpm),
-                        Decorated.custom(jarPath, DECORATION_JAR),
-                        Decorated.struct(entry.getKey()),
-                        Decorated.actual(entry.getValue()));
-            }
-        }
+        };
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/JavadocNoarchValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/JavadocNoarchValidator.java
@@ -2,11 +2,12 @@ package org.fedoraproject.javapackages.validator.validators;
 
 import org.fedoraproject.javapackages.validator.spi.Decorated;
 import org.fedoraproject.javapackages.validator.util.Common;
-import org.fedoraproject.javapackages.validator.util.ElementwiseValidator;
+import org.fedoraproject.javapackages.validator.util.ConcurrentValidator;
+import org.fedoraproject.javapackages.validator.util.ElementwiseResultBuilder;
 
 import io.kojan.javadeptools.rpm.RpmPackage;
 
-public class JavadocNoarchValidator extends ElementwiseValidator {
+public class JavadocNoarchValidator extends ConcurrentValidator {
     @Override
     public String getTestName() {
         return "/java/javadoc_noarch";
@@ -17,15 +18,20 @@ public class JavadocNoarchValidator extends ElementwiseValidator {
     }
 
     @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        if (!rpm.getInfo().getArch().equals("noarch")) {
-            fail("{0} is a javadoc package but its architecture is {1}",
-                    Decorated.rpm(rpm),
-                    Decorated.actual(rpm.getInfo().getArch()));
-        } else {
-            pass("{0} is a javadoc package and its architecture is {1}",
-                    Decorated.rpm(rpm),
-                    Decorated.actual("noarch"));
-        }
+    protected ElementwiseResultBuilder spawnValidator() {
+        return new ElementwiseResultBuilder() {
+            @Override
+            public void validate(RpmPackage rpm) throws Exception {
+                if (!rpm.getInfo().getArch().equals("noarch")) {
+                    fail("{0} is a javadoc package but its architecture is {1}",
+                            Decorated.rpm(rpm),
+                            Decorated.actual(rpm.getInfo().getArch()));
+                } else {
+                    pass("{0} is a javadoc package and its architecture is {1}",
+                            Decorated.rpm(rpm),
+                            Decorated.actual("noarch"));
+                }
+            }
+        };
     }
 }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/JpmsProvidesValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/JpmsProvidesValidator.java
@@ -30,10 +30,10 @@ public class JpmsProvidesValidator extends JarValidator {
 
     @Override
     protected RpmJarResultBuilder spawnValidator() {
-        return new JpmsProvidesResultBuilder();
+        return new JpmsResultBuilder();
     }
 
-    protected static class JpmsProvidesResultBuilder extends RpmJarResultBuilder {
+    public static class JpmsResultBuilder extends RpmJarResultBuilder {
         private Map<String, String> jarModuleNames = new TreeMap<>();
 
         @Override

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/JpmsProvidesValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/JpmsProvidesValidator.java
@@ -26,109 +26,116 @@ public class JpmsProvidesValidator extends JarValidator {
         return "/java/jpms-provides";
     }
 
-    private Map<String, String> jarModuleNames = new TreeMap<>();
-
     private static Pattern VERSIONS_PATTERN = Pattern.compile("META-INF/versions/\\d+/module-info\\.class");
 
     @Override
-    public void acceptJarEntry(RpmPackage rpm, CpioArchiveEntry rpmEntry, byte[] content) throws Exception {
-        var moduleNames = new ArrayList<Map.Entry<String, String>>();
-        var rpmEntryString = Common.getEntryPath(rpmEntry).toString();
+    protected RpmJarResultBuilder spawnValidator() {
+        return new JpmsProvidesResultBuilder();
+    }
 
-        try (var is = new JarInputStream(new ByteArrayInputStream(content))) {
-            for (JarEntry entry; (entry = is.getNextJarEntry()) != null;) {
-                if (entry.getName().equals("module-info.class")
-                        || (entry.getName().startsWith("META-INF/versions/")
-                            && VERSIONS_PATTERN.matcher(entry.getName()).matches())) {
-                    try {
-                        var md = ModuleDescriptor.read(ByteBuffer.wrap(IOUtils.toByteArray(is)));
-                        moduleNames.add(Map.entry(entry.getName(), md.name()));
-                    } catch (InvalidModuleDescriptorException e) {
-                        fail("{0}: {1}: {2}: invalid module descriptor: {3}",
-                                Decorated.rpm(rpm),
-                                Decorated.outer(rpmEntryString),
-                                Decorated.struct(entry.getRealName()),
-                                Decorated.actual(e.getMessage()));
+    protected static class JpmsProvidesResultBuilder extends RpmJarResultBuilder {
+        private Map<String, String> jarModuleNames = new TreeMap<>();
+
+        @Override
+        public void acceptJarEntry(RpmPackage rpm, CpioArchiveEntry rpmEntry, byte[] content) throws Exception {
+            var moduleNames = new ArrayList<Map.Entry<String, String>>();
+            var rpmEntryString = Common.getEntryPath(rpmEntry).toString();
+
+            try (var is = new JarInputStream(new ByteArrayInputStream(content))) {
+                for (JarEntry entry; (entry = is.getNextJarEntry()) != null;) {
+                    if (entry.getName().equals("module-info.class")
+                            || (entry.getName().startsWith("META-INF/versions/")
+                                    && VERSIONS_PATTERN.matcher(entry.getName()).matches())) {
+                        try {
+                            var md = ModuleDescriptor.read(ByteBuffer.wrap(IOUtils.toByteArray(is)));
+                            moduleNames.add(Map.entry(entry.getName(), md.name()));
+                        } catch (InvalidModuleDescriptorException e) {
+                            fail("{0}: {1}: {2}: invalid module descriptor: {3}",
+                                    Decorated.rpm(rpm),
+                                    Decorated.outer(rpmEntryString),
+                                    Decorated.struct(entry.getRealName()),
+                                    Decorated.actual(e.getMessage()));
+                        }
+                    }
+                }
+
+                if (moduleNames.isEmpty()) {
+                    var mf = is.getManifest();
+                    var moduleName = mf.getMainAttributes().getValue("Automatic-Module-Name");
+                    if (moduleName != null) {
+                        moduleNames.add(Map.entry("META-INF/MANIFEST.MF:Automatic-Module-Name", moduleName));
                     }
                 }
             }
 
-            if (moduleNames.isEmpty()) {
-                var mf = is.getManifest();
-                var moduleName = mf.getMainAttributes().getValue("Automatic-Module-Name");
-                if (moduleName != null) {
-                    moduleNames.add(Map.entry("META-INF/MANIFEST.MF:Automatic-Module-Name", moduleName));
+            for (var entry : moduleNames) {
+                debug("{0}: {1}: {2}: found module name: {3}",
+                        Decorated.rpm(rpm),
+                        Decorated.outer(rpmEntryString),
+                        Decorated.struct(entry.getKey()),
+                        Decorated.actual(entry.getValue()));
+            }
+
+            String moduleName = null;
+            for (var entry : moduleNames) {
+                if (moduleName == null) {
+                    moduleName = entry.getValue();
+                    jarModuleNames.put(rpmEntryString, moduleName);
+                } else if (! moduleName.equals(entry.getValue())) {
+                    fail("{0}: {1}: differing module names: {2} and {3}",
+                            Decorated.rpm(rpm),
+                            Decorated.outer(rpmEntryString),
+                            Decorated.struct(moduleName),
+                            Decorated.actual(entry.getValue()));
                 }
             }
         }
 
-        for (var entry : moduleNames) {
-            debug("{0}: {1}: {2}: found module name: {3}",
-                    Decorated.rpm(rpm),
-                    Decorated.outer(rpmEntryString),
-                    Decorated.struct(entry.getKey()),
-                    Decorated.actual(entry.getValue()));
-        }
+        @Override
+        public void validate(RpmPackage rpm) throws Exception {
+            jarModuleNames.clear();
+            var providedModuleNames = new TreeSet<String>();
 
-        String moduleName = null;
-        for (var entry : moduleNames) {
-            if (moduleName == null) {
-                moduleName = entry.getValue();
-                jarModuleNames.put(rpmEntryString, moduleName);
-            } else if (! moduleName.equals(entry.getValue())) {
-                fail("{0}: {1}: differing module names: {2} and {3}",
-                        Decorated.rpm(rpm),
-                        Decorated.outer(rpmEntryString),
-                        Decorated.struct(moduleName),
-                        Decorated.actual(entry.getValue()));
+            for (var reldep : rpm.getInfo().getProvides()) {
+                var name = reldep.getName();
+                if (name.startsWith("jpms(") && name.endsWith(")")) {
+                    name = name.substring(5, name.length() - 1);
+                    providedModuleNames.add(name);
+                    debug("{0}: provides JPMS name: {1}", Decorated.rpm(rpm), Decorated.actual(name));
+                }
             }
-        }
-    }
 
-    @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        jarModuleNames.clear();
-        var providedModuleNames = new TreeSet<String>();
+            super.validate(rpm);
+            boolean ok = true;
 
-        for (var reldep : rpm.getInfo().getProvides()) {
-            var name = reldep.getName();
-            if (name.startsWith("jpms(") && name.endsWith(")")) {
-                name = name.substring(5, name.length() - 1);
-                providedModuleNames.add(name);
-                debug("{0}: provides JPMS name: {1}", Decorated.rpm(rpm), Decorated.actual(name));
+            for (var providedModuleName : providedModuleNames) {
+                if (! jarModuleNames.values().contains(providedModuleName)) {
+                    ok = false;
+                    fail("{0}: module name {1} provided by this RPM was not found in any JAR file",
+                            Decorated.rpm(rpm),
+                            Decorated.actual(providedModuleName));
+                }
             }
-        }
 
-        super.validate(rpm);
-        boolean ok = true;
-
-        for (var providedModuleName : providedModuleNames) {
-            if (! jarModuleNames.values().contains(providedModuleName)) {
-                ok = false;
-                fail("{0}: module name {1} provided by this RPM was not found in any JAR file",
-                        Decorated.rpm(rpm),
-                        Decorated.actual(providedModuleName));
+            for (var jarModuleNameEntry : jarModuleNames.entrySet()) {
+                if (! providedModuleNames.contains(jarModuleNameEntry.getValue())) {
+                    ok = false;
+                    fail("{0}: {1}: module name {2} is not provided by this RPM",
+                            Decorated.rpm(rpm),
+                            Decorated.outer(jarModuleNameEntry.getKey()),
+                            Decorated.actual(jarModuleNameEntry.getValue()));
+                }
             }
-        }
 
-        for (var jarModuleNameEntry : jarModuleNames.entrySet()) {
-            if (! providedModuleNames.contains(jarModuleNameEntry.getValue())) {
-                ok = false;
-                fail("{0}: {1}: module name {2} is not provided by this RPM",
-                        Decorated.rpm(rpm),
-                        Decorated.outer(jarModuleNameEntry.getKey()),
-                        Decorated.actual(jarModuleNameEntry.getValue()));
-            }
-        }
-
-        if (ok) {
-            if (providedModuleNames.isEmpty()) {
-                skip("{0}: no JPMS module names found neither as JPMS RPM Provides nor in any Jars",
-                        Decorated.rpm(rpm));
-            } else {
-                pass("{0}: found module names exactly match provided JPMS fields, {1}",
-                        Decorated.rpm(rpm),
-                        Decorated.actual(providedModuleNames.stream().toList()));
+            if (ok) {
+                if (providedModuleNames.isEmpty()) {
+                    skip("{0}: no JPMS module names found neither as JPMS RPM Provides nor in any Jars",
+                            Decorated.rpm(rpm));
+                } else {
+                    pass("{0}: found module names exactly match provided JPMS fields, {1}",
+                            Decorated.rpm(rpm),
+                            Decorated.actual(providedModuleNames.stream().toList()));
+                }
             }
         }
     }

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/NVRJarMetadataValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/NVRJarMetadataValidator.java
@@ -72,7 +72,7 @@ public class NVRJarMetadataValidator extends DefaultValidator {
         }
     }
 
-    private static List<Entry> ENTRIES = List.of(new RpmName(), new RpmEpoch(), new RpmVersion(), new RpmRelease());
+    private static final List<Entry> ENTRIES = List.of(new RpmName(), new RpmEpoch(), new RpmVersion(), new RpmRelease());
 
     private class RpmEntry implements RpmJarConsumer {
         RpmPackage sourceRpm = null;

--- a/src/main/java/org/fedoraproject/javapackages/validator/validators/NoBootstrapValidator.java
+++ b/src/main/java/org/fedoraproject/javapackages/validator/validators/NoBootstrapValidator.java
@@ -1,23 +1,29 @@
 package org.fedoraproject.javapackages.validator.validators;
 
 import org.fedoraproject.javapackages.validator.spi.Decorated;
-import org.fedoraproject.javapackages.validator.util.ElementwiseValidator;
+import org.fedoraproject.javapackages.validator.util.ConcurrentValidator;
+import org.fedoraproject.javapackages.validator.util.ElementwiseResultBuilder;
 
 import io.kojan.javadeptools.rpm.RpmPackage;
 
-public class NoBootstrapValidator extends ElementwiseValidator {
+public class NoBootstrapValidator extends ConcurrentValidator {
     @Override
     public String getTestName() {
         return "/no-bootstrap";
     }
 
     @Override
-    public void validate(RpmPackage rpm) throws Exception {
-        Decorated suffix = Decorated.actual("~bootstrap");
-        if (rpm.getInfo().getRelease().endsWith("~bootstrap")) {
-            fail("{0}: Release ends with a {1} suffix", Decorated.rpm(rpm), suffix);
-        } else {
-            pass("{0}: Release does not end with a {1} suffix", Decorated.rpm(rpm), suffix);
-        }
+    protected ElementwiseResultBuilder spawnValidator() {
+        return new ElementwiseResultBuilder() {
+            @Override
+            public void validate(RpmPackage rpm) throws Exception {
+                Decorated suffix = Decorated.actual("~bootstrap");
+                if (rpm.getInfo().getRelease().endsWith("~bootstrap")) {
+                    fail("{0}: Release ends with a {1} suffix", Decorated.rpm(rpm), suffix);
+                } else {
+                    pass("{0}: Release does not end with a {1} suffix", Decorated.rpm(rpm), suffix);
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
Add a simple way to pass multiple file arguments for validator with simple shell expansion.

Introduce a way for a more fine-grained parallelization of validator tasks.
Implement parallel execution of each validator per each RPM file.
Implement parallel execution of the `RpmJarConsumer` per each Jar entry.
Use synchronized logging.
Change some exception signatures due to having to pack and submit tasks which do not throw.

This change deserves more attention since it introduces more parallelism and such problems are notoriously hard to find.
This change also requires a simple change to the Fedora tests.