### PR TITLE
Depend on junit-jupiter-api instead of -engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/x
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <version>5.13.3</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Depending on the full junit-jupiter-engine is incorrect when tests only use annotations and assertions from junit-jupiter-api. The test runner (Maven Surefire) brings in the engine automatically. Declaring it manually only adds unnecessary dependencies.